### PR TITLE
code to use HPE smartredis

### DIFF
--- a/buildlib.csm_share
+++ b/buildlib.csm_share
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys,os
-cimeroot = os.getenv("CIMEROOT")
-sys.path.append(os.path.join(cimeroot,"scripts","Tools"))
+_CIMEROOT = os.getenv("CIMEROOT")
+sys.path.append(os.path.join(_CIMEROOT,"scripts","Tools"))
 
 from standard_script_setup import *
 from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging, expect, symlink_force
@@ -50,7 +50,6 @@ def buildlib(bldroot, installpath, case):
 ###############################################################################
     gmake_args = get_standard_makefile_args(case, shared_lib=True)
     comp_interface = case.get_value("COMP_INTERFACE")
-    cimeroot = case.get_value("CIMEROOT")
     srcroot = case.get_value("SRCROOT")
     caseroot = case.get_value("CASEROOT")
     libroot = case.get_value("LIBROOT")
@@ -74,20 +73,23 @@ def buildlib(bldroot, installpath, case):
         if case.get_value("USE_SMARTSIM"):
             smartredis_home = os.getenv("REDIS_HOME")
             expect(smartredis_home," Expect path to SMARTREDIS in env variable REDIS_HOME")
-            filepath.append(os.path.join(smartredis_home,"src","fortran"))
-            os.environ["USER_INCLDIR"] = "-I"+os.path.join(smartredis_home,"install","include")
+            fortran_src_path = os.path.join(smartredis_home,"src","fortran")
+            expect(os.path.isdir(fortran_src_path), "Could not find or read directory {}".format(fortran_src_path))
+            filepath.append(fortran_src_path)
+            redis_include_path = os.path.join(smartredis_home,"install","include")
+            expect(os.path.isdir(redis_include_path), "Could not find or read directory {}".format(redis_include_path))
+            os.environ["USER_INCLDIR"] = "-I" + redis_include_path
             gmake_args += " USE_SMARTSIM=TRUE "
     elif comp_interface != "mct":
         expect(False, "driver value of {} not supported".format(comp_interface))
 
-    if case.get_value("USE_ESMF_LIB"):
+    if comp_interface == "nuopc" or case.get_value("USE_ESMF_LIB"):
         use_esmf = "esmf"
     else:
         use_esmf = "noesmf"
         filepath.append(os.path.join(srcroot,"share","src","esmf_wrf_timemgr"))
 
 
-    comp_interface = case.get_value("COMP_INTERFACE")
     ninst_value = case.get_value("NINST_VALUE")
     libdir = os.path.join(bldroot,comp_interface,use_esmf, ninst_value,"csm_share")
     if not os.path.isdir(libdir):

--- a/buildlib.csm_share
+++ b/buildlib.csm_share
@@ -71,10 +71,12 @@ def buildlib(bldroot, installpath, case):
     if comp_interface == "nuopc":
         filepath.append(os.path.join(srcroot,"share","cmeps"))
         filepath.append(os.path.join(srcroot,"components","cmeps", "nuopc_cap_share"))
-        smartredis_home = os.getenv("SMARTREDIS_HOME")
-        if smartredis_home:
+        if case.get_value("USE_SMARTSIM"):
+            smartredis_home = os.getenv("REDIS_HOME")
+            expect(smartredis_home," Expect path to SMARTREDIS in env variable REDIS_HOME")
             filepath.append(os.path.join(smartredis_home,"src","fortran"))
             os.environ["USER_INCLDIR"] = "-I"+os.path.join(smartredis_home,"install","include")
+            gmake_args += " USE_SMARTSIM=TRUE "
     elif comp_interface != "mct":
         expect(False, "driver value of {} not supported".format(comp_interface))
 

--- a/buildlib.csm_share
+++ b/buildlib.csm_share
@@ -71,6 +71,10 @@ def buildlib(bldroot, installpath, case):
     if comp_interface == "nuopc":
         filepath.append(os.path.join(srcroot,"share","cmeps"))
         filepath.append(os.path.join(srcroot,"components","cmeps", "nuopc_cap_share"))
+        smartredis_home = os.getenv("SMARTREDIS_HOME")
+        if smartredis_home:
+            filepath.append(os.path.join(smartredis_home,"src","fortran"))
+            os.environ["USER_INCLDIR"] = "-I"+os.path.join(smartredis_home,"install","include")
     elif comp_interface != "mct":
         expect(False, "driver value of {} not supported".format(comp_interface))
 


### PR DESCRIPTION
This adds an interface to the HPE SmartSim database.  The fortran interface in SmartRedis must
be compiled to be used, this adds them to the cesm share directory thus making them available to
all cesm components.  