### PR TITLE
add short datatype to pio stubs

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -150,6 +150,7 @@ jobs:
           export NETCDF=$HOME/netcdf-fortran
           export PATH=$NETCDF/bin:$PATH
           export LD_LIBRARY_PATH=$NETCDF/lib:$HOME/pnetcdf/lib:$LD_LIBRARY_PATH
+          export CIME_TEST_PLATFORM=ubuntu-latest
           python -m pip install pytest pytest-cov
           pytest -vvv --no-fortran-run --compiler gnu --mpilib openmpi --machine ubuntu-latest
 

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -25,10 +25,10 @@ jobs:
       CXX: mpicxx
       CPPFLAGS: "-I/usr/include -I/usr/local/include"
       # Versions of all dependencies can be updated here
-      PNETCDF_VERSION: pnetcdf-1.12.2
+      PNETCDF_VERSION: pnetcdf-1.12.3
       NETCDF_FORTRAN_VERSION: v4.5.2
       MCT_VERSION: MCT_2.11.0
-      PARALLELIO_VERSION: pio2_5_4
+      PARALLELIO_VERSION: pio2_5_6
       NETCDF_C_PATH: /usr
       NETCDF_FORTRAN_PATH: ${HOME}/netcdf-fortran
       PNETCDF_PATH: ${HOME}/pnetcdf
@@ -130,7 +130,7 @@ jobs:
           ln -fs $clibdir/lib* .
 
       - name: Cache inputdata
-        id: cache-inputdata
+        if: ${{ ! env.ACT }}
         uses: actions/cache@v2
         with:
           path: $HOME/cesm/inputdata

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -156,6 +156,6 @@ jobs:
 
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
-#      - name: Setup tmate session
-#        if: ${{ failure() }}
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           repository: ESMCI/cime
 
+      - name: genf90 checkout
+        uses: actions/checkout@v2
+        with:
+          repository: PARALLELIO/genf90
+          path: CIME/non_py/externals/genf90
+
       - name: ccs_config checkout
         uses: actions/checkout@v2
         with:

--- a/unit_test_stubs/pio/pio.F90.in
+++ b/unit_test_stubs/pio/pio.F90.in
@@ -57,6 +57,7 @@ module pio
   end type PIO_rearr_opt_t
 
   integer, parameter, private ::          &
+       i2        = selected_int_kind(2)   ,&
        i4        = selected_int_kind(6)   ,&
        i8        = selected_int_kind(13)  ,&
        r4        = selected_real_kind(6)  ,&
@@ -652,7 +653,7 @@ contains
     ierr = 0
   end function put_att_{TYPE}
 
-! TYPE real,double,int
+! TYPE real,double,int,short
   integer function put_att_1d_{TYPE} (File, varid, name, value) result(ierr)
     type (File_desc_t), intent(inout) , target :: File
     integer, intent(in) :: varid
@@ -671,7 +672,7 @@ contains
     ierr = 0
   end function put_att_desc_{TYPE}
 
-! TYPE real,int,double
+! TYPE real,int,double,short
   integer function put_att_desc_1d_{TYPE} (File,varDesc,name,value) result(ierr)
     type (File_desc_t), intent(inout) , target :: File
     type (VAR_desc_t), intent(in)     :: varDesc
@@ -689,7 +690,7 @@ contains
     ierr = 0
   end function put_var1_text
 
-! TYPE int,real,double
+! TYPE int,real,double,short
   integer function put_var1_{TYPE} (File,varid, index, ival) result(ierr)
     type (File_desc_t), intent(inout) :: File
     integer, intent(in) :: varid, index(:)
@@ -718,7 +719,7 @@ contains
   end function put_var_{DIMS}d_text
 
 ! DIMS 1,2,3,4,5
-! TYPE int,real,double
+! TYPE int,real,double,short
   integer function put_var_{DIMS}d_{TYPE} (File,varid, ival) result(ierr)
     type (File_desc_t), intent(inout) :: File
     integer, intent(in) :: varid
@@ -727,7 +728,7 @@ contains
     ierr = 0
   end function put_var_{DIMS}d_{TYPE}
 
-! TYPE int,real,double
+! TYPE int,real,double,short
   integer function put_var_0d_{TYPE} (File,varid, ival) result(ierr)
     type (File_desc_t), intent(inout) :: File
     integer, intent(in) :: varid
@@ -755,7 +756,7 @@ contains
     ierr = 0
   end function put_vara_{DIMS}d_text
 
-! TYPE int,real,double
+! TYPE int,real,double,short
 ! DIMS 1,2,3,4,5
   integer function put_vara_{DIMS}d_{TYPE} (File,varid, start, count, ival) result(ierr)
     type (File_desc_t), intent(inout) :: File


### PR DESCRIPTION
pio2 now supports a short datatype, this includes that datatype in pio stubs so that unit_tests work.