### PR TITLE
make cime checkout submodules (genf90)

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ESMCI/cime
-
-      - name: genf90 checkout
-        uses: actions/checkout@v2
-        with:
-          repository: PARALLELIO/genf90
-          path: CIME/non_py/externals/genf90
+          submodules: True
+#      - name: genf90 checkout
+#        uses: actions/checkout@v2
+#        with:
+#          repository: PARALLELIO/genf90
+#          path: CIME/non_py/externals/genf90
 
       - name: ccs_config checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Checkout cime with submodules instead of explicitly getting genf90