### PR TITLE
make sure rpfile has no left space

### DIFF
--- a/src/nuopc_shr_methods.F90
+++ b/src/nuopc_shr_methods.F90
@@ -850,6 +850,7 @@ contains
           endif
        endif
     endif
+    rpfile = adjustl(rpfile)
   end subroutine shr_get_rpointer_name
 
   logical function chkerr(rc, line, file)


### PR DESCRIPTION
nag and gnu compilers were adding a space on the left, this change removes it.   