### PR TITLE
Minor fix for unit tests on Apple systems with the Clang compiler

### DIFF
--- a/test/unit/dynamic_vector/CMakeLists.txt
+++ b/test/unit/dynamic_vector/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(.)
 
 # Because these tests use type parameterization, unfortunately we need to
 # preprocess *before* running the pFUnit preprocessor, then again *after*.
-if(${CMAKE_C_COMPILER_ID} STREQUAL GNU OR ${CMAKE_C_COMPILER_ID} STREQUAL Clang)
+if(${CMAKE_C_COMPILER_ID} STREQUAL GNU OR ${CMAKE_C_COMPILER_ID} STREQUAL Clang OR ${CMAKE_C_COMPILER_ID} STREQUAL AppleClang)
   function(make_cpp_command varname start_file end_file)
     set(${varname} ${CMAKE_C_COMPILER} -E -x c ${start_file} -o ${end_file}
       PARENT_SCOPE)


### PR DESCRIPTION
This was needed for unit testing on my Mac. I still haven't been able to run the share unit tests on my Mac, but this at least got me a bit further.