### PR TITLE
Bring in shr_reprosum fixes from E3SM

### DIFF
--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -563,7 +563,7 @@ module shr_reprosum_mod
                                          !  integer expansion to use
       integer :: max_level               ! maximum value in max_levels
 
-      real(r8) :: xmax_nsummands         ! dble of max_nsummands
+      real(r8) :: xmax_nsummands         ! real(max_nsummands,r8)
       real(r8) :: arr_lsum(nflds)        ! local sums
       real(r8) :: arr_gsum_fast(nflds)   ! global sum calculated using
                                          !  fast, nonreproducible,
@@ -701,7 +701,7 @@ module shr_reprosum_mod
 ! performance for loopb in shr_reprosum_int
             max_level = (64/nflds) + 1
             do ifld=1,nflds
-               if ((arr_gbl_max(ifld) .ge. 0.0_r8) .and. &
+               if ((arr_gbl_max(ifld) >= 0.0_r8) .and. &
                    (arr_max_levels(ifld) > 0)) then
 
                   arr_gmax_exp(ifld)  = exponent(arr_gbl_max(ifld))
@@ -756,7 +756,7 @@ module shr_reprosum_mod
 ! and sums over threads and tasks, and the smaller value used. This is
 ! equivalent to using max_nsummands as defined above.
 
-               xmax_nsummands = dble(max_nsummands)
+               xmax_nsummands = real(max_nsummands,r8)
                arr_max_shift = digits(1_i8) - (exponent(xmax_nsummands) + 1)
                if (arr_max_shift < 2) then
                   call shr_sys_abort('repro_sum failed: number of summands too '// &
@@ -825,7 +825,7 @@ module shr_reprosum_mod
                   arr_exp_tlmax = MINEXPONENT(1.0_r8)
                   if (.not. arr_gsum_infnan(ifld)) then
                      do isum=isum_beg(ithread),isum_end(ithread)
-                        if (arr(isum,ifld) .ne. 0.0_r8) then
+                        if (arr(isum,ifld) /= 0.0_r8) then
                            arr_exp = exponent(arr(isum,ifld))
                            arr_exp_tlmin = min(arr_exp,arr_exp_tlmin)
                            arr_exp_tlmax = max(arr_exp,arr_exp_tlmax)
@@ -896,7 +896,7 @@ module shr_reprosum_mod
 ! and sums over threads and tasks, and the smaller value used. This is
 ! equivalent to using max_nsummands as defined above.
 
-            xmax_nsummands = dble(max_nsummands)
+            xmax_nsummands = real(max_nsummands,r8)
             arr_max_shift = digits(1_i8) - (exponent(xmax_nsummands) + 1)
             if (arr_max_shift < 2) then
                call shr_sys_abort('repro_sum failed: number of summands too '// &
@@ -1214,7 +1214,7 @@ module shr_reprosum_mod
           do isum=isum_beg(ithread),isum_end(ithread)
             arr_remainder = 0.0_r8
 
-            if (arr(isum,ifld) .ne. 0.0_r8) then
+            if (arr(isum,ifld) /= 0.0_r8) then
                arr_exp   = exponent(arr(isum,ifld))
                arr_frac  = fraction(arr(isum,ifld))
 
@@ -1242,7 +1242,7 @@ module shr_reprosum_mod
                   ilevel = 1
                endif
 
-               if (ilevel .le. max_levels(ifld)) then
+               if (ilevel <= max_levels(ifld)) then
 ! apply first shift/truncate, add it to the relevant running
 ! sum, and calculate the remainder.
                   arr_remainder = scale(arr_frac,arr_shift)
@@ -1253,7 +1253,7 @@ module shr_reprosum_mod
 
 ! while the remainder is non-zero, continue to shift, truncate,
 ! sum, and calculate new remainder
-                  do while ((arr_remainder .ne. 0.0_r8) &
+                  do while ((arr_remainder /= 0.0_r8) &
                      .and. (ilevel < max_levels(ifld)))
                      ilevel = ilevel + 1
                      arr_remainder = scale(arr_remainder,arr_max_shift)
@@ -1266,7 +1266,7 @@ module shr_reprosum_mod
                endif
             endif
 
-            if (arr_remainder .ne. 0.0_r8) then
+            if (arr_remainder /= 0.0_r8) then
                not_exact(ifld,ithread) = 1
             endif
 
@@ -1281,7 +1281,7 @@ module shr_reprosum_mod
           do ilevel=max_levels(ifld),1,-1
              RX_8 = i8_arr_tlsum_level(ilevel,ifld,ithread)
              IX_8 = int(scale(RX_8,-arr_max_shift),i8)
-             if (IX_8 .ne. 0_i8) then
+             if (IX_8 /= 0_i8) then
                 i8_arr_tlsum_level(ilevel-1,ifld,ithread) = &
                    i8_arr_tlsum_level(ilevel-1,ifld,ithread) + IX_8
                 IX_8 = IX_8*(i8_radix**arr_max_shift)
@@ -1364,7 +1364,7 @@ module shr_reprosum_mod
 ! if validate is .true., test whether the summand upper bound
 !  was exceeded on any of the MPI tasks
          if (validate) then
-            if (i8_arr_gsum_level(ioffset-voffset+1) .ne. 0_i8) then
+            if (i8_arr_gsum_level(ioffset-voffset+1) /= 0_i8) then
                recompute = .true.
             endif
          endif
@@ -1378,7 +1378,7 @@ module shr_reprosum_mod
            do ilevel=max_levels(ifld),1,-1
              RX_8 = i8_arr_gsum_level(ioffset+ilevel)
              IX_8 = int(scale(RX_8,-arr_max_shift),i8)
-             if (IX_8 .ne. 0_i8) then
+             if (IX_8 /= 0_i8) then
                i8_arr_gsum_level(ioffset+ilevel-1) = i8_arr_gsum_level(ioffset+ilevel-1) &
                                                    + IX_8
                IX_8 = IX_8*(i8_radix**arr_max_shift)
@@ -1391,7 +1391,7 @@ module shr_reprosum_mod
 !     of accuracy arising from difference of large values when
 !     reconstructing r8 sum from integer vector)
            ilevel = 0
-           do while ((i8_arr_gsum_level(ioffset+ilevel) .eq. 0_i8) &
+           do while ((i8_arr_gsum_level(ioffset+ilevel) == 0_i8) &
                      .and. (ilevel < max_levels(ifld)))
              ilevel = ilevel + 1
            enddo
@@ -1404,7 +1404,7 @@ module shr_reprosum_mod
               endif
               do jlevel=ilevel,max_levels(ifld)-1
                  if (sign(1_i8,i8_arr_gsum_level(ioffset+jlevel)) &
-                     .ne. sign(1_i8,i8_arr_gsum_level(ioffset+jlevel+1))) then
+                     /= sign(1_i8,i8_arr_gsum_level(ioffset+jlevel+1))) then
                     i8_arr_gsum_level(ioffset+jlevel)   = i8_arr_gsum_level(ioffset+jlevel) &
                                                         - i8_sign
                     i8_arr_gsum_level(ioffset+jlevel+1) = i8_arr_gsum_level(ioffset+jlevel+1) &
@@ -1420,7 +1420,7 @@ module shr_reprosum_mod
             first = .true.
             do ilevel=max_levels(ifld),0,-1
 
-               if (i8_arr_gsum_level(ioffset+ilevel) .ne. 0_i8) then
+               if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
                   jlevel = 1
 
 ! r8 representation of higher order bits in integer
@@ -1432,7 +1432,7 @@ module shr_reprosum_mod
                   RX_8 = (i8_arr_gsum_level(ioffset+ilevel) - IX_8)
 
 ! repeat using remainder
-                  do while (RX_8 .ne. 0.0_r8)
+                  do while (RX_8 /= 0.0_r8)
                      jlevel = jlevel + 1
                      X_8(jlevel) = RX_8
                      LX(jlevel) = exponent(RX_8)
@@ -1465,7 +1465,7 @@ module shr_reprosum_mod
 ! apply final exponent correction, scaling first if exponent is too small
 ! to apply directly
             corr_exp = curr_exp + exponent(arr_gsum(ifld))
-            if (corr_exp .ge. MINEXPONENT(1.0_r8)) then
+            if (corr_exp >= MINEXPONENT(1.0_r8)) then
                arr_gsum(ifld) = set_exponent(arr_gsum(ifld),corr_exp)
             else
                RX_8 = set_exponent(arr_gsum(ifld), &
@@ -1478,14 +1478,14 @@ module shr_reprosum_mod
 !  of levels of expansion, cancellation, .... Calculated by comparing lower
 !  bound on number of sigificant digits with number of digits in 1.0_r8 .
             if (validate) then
-               if (i8_arr_gsum_level(ioffset-voffset+2) .ne. 0_i8) then
+               if (i8_arr_gsum_level(ioffset-voffset+2) /= 0_i8) then
 
 ! find first nonzero level and use exponent for this level, then assume all
 ! subsequent levels contribute arr_max_shift digits.
                   sum_digits = 0
                   do ilevel=0,max_levels(ifld)
-                     if (sum_digits .eq. 0) then
-                        if (i8_arr_gsum_level(ioffset+ilevel) .ne. 0_i8) then
+                     if (sum_digits == 0) then
+                        if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
                            X_8(1) = i8_arr_gsum_level(ioffset+ilevel)
                            LX(1)  = exponent(X_8(1))
                            sum_digits = LX(1)

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -9,19 +9,21 @@ module shr_reprosum_mod
 ! Compute using either or both a scalable, reproducible algorithm and a
 ! scalable, nonreproducible algorithm:
 ! * Reproducible (scalable):
-!    Convert to fixed point (integer vector representation) to enable
-!    reproducibility when using MPI_Allreduce
+!    Convert each floating point summand to an integer vector
+!    representation, to enable reproducibility when using
+!    MPI_Allreduce, then convert the resulting global sum back to a
+!    floating point representation locally;
 ! * Alternative usually reproducible (scalable):
 !    Use parallel double-double algorithm due to Helen He and
-!    Chris Ding, based on David Bailey's/Don Knuth's DDPDD algorithm
+!    Chris Ding, based on David Bailey's/Don Knuth's DDPDD algorithm;
 ! * Nonreproducible (scalable):
 !    Floating point and MPI_Allreduce based.
 ! If computing both reproducible and nonreproducible sums, compare
 ! these and report relative difference (if absolute difference
 ! less than sum) or absolute difference back to calling routine.
 !
-! Author: P. Worley (based on suggestions from J. White for fixed
-!                    point algorithm and on He/Ding paper for ddpdd
+! Author: P. Worley (based on suggestions from J. White for integer
+!                    vector algorithm and on He/Ding paper for DDPDD
 !                    algorithm)
 !
 !-----------------------------------------------------------------------
@@ -110,7 +112,7 @@ module shr_reprosum_mod
 ! Author: P. Worley
 !-----------------------------------------------------------------------
 !------------------------------Arguments--------------------------------
-      ! Use DDPDD algorithm instead of fixed precision algorithm
+      ! Use DDPDD algorithm instead of integer vector algorithm
       logical, intent(in), optional :: repro_sum_use_ddpdd_in
       ! Allow INF or NaN in summands
       logical, intent(in), optional :: repro_sum_allow_infnan_in
@@ -168,7 +170,7 @@ module shr_reprosum_mod
               'distributed sum algorithm'
          else
             write(logunit,*) 'SHR_REPROSUM_SETOPTS: ',&
-              'Using fixed-point-based (scalable) reproducible ', &
+              'Using integer-vector-based (scalable) reproducible ', &
               'distributed sum algorithm'
          endif
 
@@ -190,7 +192,7 @@ module shr_reprosum_mod
                  'a serial algorithm.'
             else
                write(logunit,*) '                    ',&
-                 'If tolerance exceeded, fixed-precision is sum used ', &
+                 'If tolerance exceeded, integer-vector-based sum is used ', &
                  'but a warning is output.'
             endif
          else
@@ -215,12 +217,15 @@ module shr_reprosum_mod
 !----------------------------------------------------------------------
 !
 ! Purpose:
-! Compute the global sum of each field in "arr" using the indicated
+! Compute the global sum of each field in 'arr' using the indicated
 ! communicator with a reproducible yet scalable implementation based
-! on a fixed point algorithm. An alternative is to use an "almost
-! always reproducible" floating point algorithm, as described below.
+! on first converting each floating point summand into an equivalent
+! representation using a vector of integers, summing the integer
+! vectors, then converting the resulting sum back to a floating point
+! representation. An alternative is to use an 'almost always
+! reproducible' floating point algorithm (DDPDD), as described below.
 !
-! The accuracy of the fixed point algorithm is controlled by the
+! The accuracy of the integer vector algorithm is controlled by the
 ! number of "levels" of integer expansion. The algorithm will calculate
 ! the number of levels that is required for the sum to be essentially
 ! exact. (The sum as represented by the integer expansion will be exact,
@@ -279,11 +284,11 @@ module shr_reprosum_mod
 ! precision summation of double precision values with 10 double
 ! precision operations. The advantage of this algorithm is that
 ! it requires a single MPI_Allreduce and is less expensive per summand
-! than is the fixed precision algorithm. The disadvantage is that it
+! than is the integer vector algorithm. The disadvantage is that it
 ! is not guaranteed to be reproducible (though it is reproducible
 ! much more often than is the standard algorithm). This alternative
 ! is used when the optional parameter ddpdd_sum is set to .true. It is
-! also used if the fixed precision algorithm radix assumption does not
+! also used if the integer vector algorithm radix assumption does not
 ! hold.
 !
 !----------------------------------------------------------------------
@@ -301,7 +306,7 @@ module shr_reprosum_mod
 
       logical,  intent(in),    optional :: ddpdd_sum
                                          ! use ddpdd algorithm instead
-                                         ! of fixed precision algorithm
+                                         ! of integer vector algorithm
 
       logical,  intent(in),    optional :: allow_infnan
          ! if .true., allow INF or NaN input values.
@@ -350,8 +355,8 @@ module shr_reprosum_mod
 
       real(r8), intent(out),   optional :: rel_diff(2,nflds)
                                          ! relative and absolute
-                                         !  differences between fixed
-                                         !  and floating point sums
+                                         !  differences between integer
+                                         !  vector and floating point sums
 
       integer,  intent(in),    optional :: commid
                                          ! MPI communicator
@@ -427,7 +432,7 @@ module shr_reprosum_mod
                                          !  fast, nonreproducible,
                                          !  floating point alg.
       real(r8) :: abs_diff               ! absolute difference between
-                                         !  fixed and floating point
+                                         !  integer vector and floating point
                                          !  sums
 #ifdef _OPENMP
       integer omp_get_max_threads
@@ -618,7 +623,7 @@ module shr_reprosum_mod
                arr_max_shift = digits(0_i8) - (exponent(xmax_nsummands) + 1)
                if (arr_max_shift < 2) then
                   call shr_sys_abort('repro_sum failed: number of summands too '// &
-                                     'large for fixed precision algorithm' )
+                                     'large for integer vector algorithm' )
                endif
 
 ! calculate sum
@@ -758,7 +763,7 @@ module shr_reprosum_mod
             arr_max_shift = digits(0_i8) - (exponent(xmax_nsummands) + 1)
             if (arr_max_shift < 2) then
                call shr_sys_abort('repro_sum failed: number of summands too '// &
-                                  'large for fixed precision algorithm' )
+                                  'large for integer vector algorithm' )
             endif
 
 ! determine maximum number of levels required for each field
@@ -804,7 +809,7 @@ module shr_reprosum_mod
 #endif
       endif
 
-! compare fixed and floating point results
+! compare integer vector and floating point results
       if ( present(rel_diff) ) then
          if (shr_reprosum_reldiffmax >= 0.0_r8) then
 #ifdef TIMING
@@ -896,11 +901,14 @@ module shr_reprosum_mod
 !----------------------------------------------------------------------
 !
 ! Purpose:
-! Compute the global sum of each field in "arr" using the indicated
+! Compute the global sum of each field in 'arr' using the indicated
 ! communicator with a reproducible yet scalable implementation based
-! on a fixed point algorithm. The accuracy of the fixed point algorithm
-! is controlled by the number of "levels" of integer expansion, the
-! maximum value of which is specified by max_level.
+! on first converting each floating point summand into an equivalent
+! representation using a vector of integers, summing the integer
+! vectors, then converting the resulting sum back to a floating point
+! representation. The accuracy of the integer vector algorithm is
+! controlled by the number of 'levels' of integer expansion, the maximum
+! value of which is specified by max_level.
 !
 !----------------------------------------------------------------------
 !
@@ -1377,8 +1385,8 @@ module shr_reprosum_mod
                                               !  written to
       real(r8), intent(in) :: rel_diff(2,nflds)
                                               ! relative and absolute
-                                              !  differences between fixed
-                                              !  and floating point sums
+                                              !  differences between integer
+                                              !  vector and floating point sums
 
 !
 ! Local workspace
@@ -1425,7 +1433,7 @@ module shr_reprosum_mod
       if (exceeds_limit > 0) then
          if (master) then
             write(llogunit,*) trim(name), &
-                            ': difference in fixed and floating point sums ', &
+                            ': difference between integer vector and floating point sums ', &
                             ' exceeds tolerance in ', exceeds_limit, &
                             ' fields.'
             write(llogunit,*) '  Maximum relative diff: (rel)', &

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -562,6 +562,9 @@ module shr_reprosum_mod
       integer :: max_levels(nflds)       ! maximum number of levels of
                                          !  integer expansion to use
       integer :: max_level               ! maximum value in max_levels
+      integer :: extra_levels            ! number of extra levels needed
+                                         !  to guarantee that sum over threads
+                                         !  or tasks does not cause overflow
 
       real(r8) :: xmax_nsummands         ! real(max_nsummands,r8)
       real(r8) :: arr_lsum(nflds)        ! local sums
@@ -736,15 +739,16 @@ module shr_reprosum_mod
 #ifdef TIMING
                call t_stopf("repro_sum_allr_max")
 #endif
-! Determine maximum shift. Shift needs to be small enough that summation
-! does not exceed maximum number of digits in i8.
+! Determine maximum shift. Shift needs to be small enough that summation,
+! in absolute value, does not exceed maximum value representable by i8.
 
 ! If requested, return max_nsummands before it is redefined
                if ( present( gbl_max_nsummands_out) ) then
                   gbl_max_nsummands_out = max_nsummands
                endif
 
-! Summing within each thread first
+! Summing within each thread first (adding 1 to max_nsummands
+! to ensure that integer division rounds up)
                max_nsummands = (max_nsummands/omp_nthreads) + 1
 ! then over threads and tasks
                max_nsummands = max(max_nsummands, tasks*omp_nthreads)
@@ -762,6 +766,25 @@ module shr_reprosum_mod
                   call shr_sys_abort('repro_sum failed: number of summands too '// &
                                      'large for integer vector algorithm' )
                endif
+! Note: by construction, each floating point value will be decomposed
+! into a vector of integers each component of which will be strictly
+! less than radix(1_i8)**arr_max_shift in absolute value, and the
+! summation of max_nsummands of these, again in absolute value, will
+! then be less than 
+!  radix(1_i8)**(arr_max_shift + exponent(xmax_nsummands))
+! or radix(1_i8)**(digits(1_i8) - 1). This is more conservative than
+! necessary, but it also allows the postprocessing mentioned above
+! (and described later) to proceed without danger of introducing
+! overflow. 
+
+! Determine additional number of levels needed to support the
+! postprocessing that reduces the magnitude of each component
+! of the integer vector of the partial sum for each thread
+! to be less than (radix(1_i8)**arr_max_shift).
+               extra_levels = (digits(1_i8) - 1)/arr_max_shift
+! Extra levels are indexed by (-(extra_levels-1):0)
+! Derivation of this is described in the comments in
+! shr_reprosum_int.
 
 ! Calculate sum
                if (present(repro_sum_validate)) then
@@ -771,8 +794,9 @@ module shr_reprosum_mod
                endif
                call shr_reprosum_int(arr, arr_gsum, nsummands, dsummands, &
                                      nflds, arr_max_shift, arr_gmax_exp, &
-                                     arr_max_levels, max_level, arr_gsum_infnan, &
-                                     validate, recompute, omp_nthreads, mpi_comm)
+                                     arr_max_levels, max_level, extra_levels, &
+                                     arr_gsum_infnan, validate, recompute, &
+                                     omp_nthreads, mpi_comm)
 
 ! Record statistics, etc.
                repro_sum_fast = 1
@@ -881,10 +905,11 @@ module shr_reprosum_mod
             endif
 
 ! Determine maximum shift (same as in previous branch, but with calculated
-! max_nsummands). Shift needs to be small enough that summation does not
-! exceed maximum number of digits in i8.
+! max_nsummands). Shift needs to be small enough that summation, in absolute
+! value, does not exceed maximum value representable by i8.
 
-! Summing within each thread first
+! Summing within each thread first (adding 1 to max_nsummands
+! to ensure that integer division rounds up)
             max_nsummands = (max_nsummands/omp_nthreads) + 1
 ! then over threads and tasks
             max_nsummands = max(max_nsummands, tasks*omp_nthreads)
@@ -902,6 +927,16 @@ module shr_reprosum_mod
                call shr_sys_abort('repro_sum failed: number of summands too '// &
                                   'large for integer vector algorithm' )
             endif
+! Note: by construction, each floating point value will be decomposed
+! into a vector of integers each component of which will be strictly
+! less than radix(1_i8)**arr_max_shift in absolute value, and the
+! summation of max_nsummands of these, again in absolute value, will
+! then be less than 
+!  radix(1_i8)**(arr_max_shift + exponent(xmax_nsummands))
+! or radix(1_i8)**(digits(1_i8) - 1). This is more conservative than
+! necessary, but it also allows the postprocessing mentioned above
+! (and described later) to proceed without danger of introducing
+! overflow. 
 
 ! Determine maximum number of levels required for each field.
 ! Need enough levels to represent both the smallest and largest
@@ -943,12 +978,22 @@ module shr_reprosum_mod
                enddo
             endif
 
+! Determine additional number of levels needed to support the
+! postprocessing that reduces the magnitude of each component
+! of the integer vector of the partial sum for each thread
+! to be less than (radix(1_i8)**arr_max_shift).
+            extra_levels = (digits(1_i8) - 1)/arr_max_shift
+! Extra levels are indexed by (-(extra_levels-1):0)
+! Derivation of this is described in the comments in
+! shr_reprosum_int.
+
 ! Calculate sum
             validate = .false.
             call shr_reprosum_int(arr, arr_gsum, nsummands, dsummands, &
                                   nflds, arr_max_shift, arr_gmax_exp, &
-                                  max_levels, max_level, arr_gsum_infnan, &
-                                  validate, recompute, omp_nthreads, mpi_comm)
+                                  max_levels, max_level, extra_levels, &
+                                  arr_gsum_infnan, validate, recompute, &
+                                  omp_nthreads, mpi_comm)
 
          endif
 #ifdef TIMING
@@ -1042,8 +1087,8 @@ module shr_reprosum_mod
 
    subroutine shr_reprosum_int (arr, arr_gsum, nsummands, dsummands, nflds, &
                                 arr_max_shift, arr_gmax_exp, max_levels,    &
-                                max_level, skip_field, validate, recompute, &
-                                omp_nthreads, mpi_comm                      )
+                                max_level, extra_levels, skip_field,        &
+                                validate, recompute, omp_nthreads, mpi_comm )
 !------------------------------------------------------------------------
 !
 ! Purpose:
@@ -1073,6 +1118,10 @@ module shr_reprosum_mod
                                             !  of integer expansion
       integer,  intent(in) :: max_level     ! maximum value in
                                             !  max_levels
+      integer,  intent(in) :: extra_levels  ! number of extra levels
+                                            ! needed to guarantee that
+                                            ! sum over threads or tasks
+                                            ! does not cause overflow
       integer,  intent(in) :: omp_nthreads  ! number of OpenMP threads
       integer,  intent(in) :: mpi_comm      ! MPI subcommunicator
 
@@ -1100,15 +1149,15 @@ module shr_reprosum_mod
       integer, parameter  :: max_jlevel = &
                                 1 + (digits(1_i8)/digits(1.0_r8))
 
-      integer(i8) :: i8_arr_tlsum_level(0:max_level,nflds,omp_nthreads)
+      integer(i8) :: i8_arr_tlsum_level(-(extra_levels-1):max_level,nflds,omp_nthreads)
                                    ! integer vector representing local
                                    !  sum (per thread, per field)
-      integer(i8) :: i8_arr_lsum_level((max_level+3)*nflds)
+      integer(i8) :: i8_arr_lsum_level((max_level+extra_levels+2)*nflds)
                                    ! integer vector representing local
                                    !  sum
       integer(i8) :: i8_arr_level  ! integer part of summand for current
                                    !  expansion level
-      integer(i8) :: i8_arr_gsum_level((max_level+3)*nflds)
+      integer(i8) :: i8_arr_gsum_level((max_level+extra_levels+2)*nflds)
                                    ! integer vector representing global
                                    !  sum
       integer(i8) :: IX_8          ! integer representation of current
@@ -1137,6 +1186,8 @@ module shr_reprosum_mod
                                    !  expansion of current ifld
       integer :: voffset           ! modification to offset used to
                                    !  include validation metrics
+      integer :: min_level         ! index of minimum levels (including
+                                   !  extra levels) for i8_arr_tlsum_level
       integer :: ioffset           ! offset(ifld)
       integer :: jlevel            ! number of floating point 'pieces'
                                    !  extracted from a given i8 integer
@@ -1171,12 +1222,15 @@ module shr_reprosum_mod
       i8_radix = radix(IX_8)
 
 ! If validating upper bounds, reserve space for validation metrics
-! In both cases, reserve an extra level for overflow from the top level
+! In both cases, reserve extra levels for overflows from the top level
       if (validate) then
-        voffset = 3
+        voffset = extra_levels + 2
       else
-        voffset = 1
+        voffset = extra_levels
       endif
+
+! For convenience, define minimum level index for i8_arr_tlsum_level
+      min_level = -(extra_levels-1)
 
 ! Compute offsets for each field
       offset(1) = voffset
@@ -1272,18 +1326,73 @@ module shr_reprosum_mod
 
           enddo
 
-! Postprocess integer vector to eliminate potential for overlap in the following
-! sums over threads and MPI tasks: if value larger than or equal to
-! (radix(IX_8)**arr_max_shift), add this 'overlap' to next larger integer in
-! vector, resulting in nonoverlapping ranges for each component. Note that
-! 'ilevel-1==0' corresponds to an extra level used to guarantee that the sums
-! over threads and MPI tasks do not overflow for ilevel==1.
-          do ilevel=max_levels(ifld),1,-1
-             RX_8 = i8_arr_tlsum_level(ilevel,ifld,ithread)
-             IX_8 = int(scale(RX_8,-arr_max_shift),i8)
-             if (IX_8 /= 0_i8) then
+! Postprocess integer vector to eliminate possibility of overflow
+! during subsequent sum over threads and tasks, as per earlier
+! comment on logic behind definition of max_nsummands. If value at a
+! given level is larger than or equal to
+! (radix(1_i8)**arr_max_shift), subtract this 'overlap' from the
+! current value and add it (appropriately shifted) to the value at
+! the next smaller level in the vector.
+! (a) As described earlier, prior to this postprocessing the integer
+!     components are each strictly less than
+!     radix(1_i8)**(digits(1_i8) - 1) in absolute value. So, after
+!     shifting, the absolute value of the amount added to level
+!     max_levels(ifld)-1 from level max_levels(ifld) is less than
+!     radix(1_i8)**(digits(1_i8) - 1 - arr_max_shift) with the
+!     resulting sum, in absolute value, being less than
+!      (radix(1_i8)**(digits(1_i8) - 1))*(1 + radix(1_i8)**(-arr_max_shift)).
+!     Any overlap from this component is then added to the level
+!     max_levels(ifld)-2, etc., with resulting intermediate sums, in
+!     absolute value, for levels 1 to max_levels(ifld) being bounded
+!     from above by 
+!      (radix(1_i8)**(digits(1_i8) - 1))*sum{i=0,inf}(radix(1_i8)**(-i*arr_max_shift)).
+!     Since radix(1_i8) >= 2 and arr_max_shift is also required to be
+!     >= 2 (otherwise the code exits with an error) this is less than
+!     or equal to 
+!      (radix(1_i8)**(digits(1_i8) - 1))*sum{i=0,inf}(2**(-2i)),
+!     or
+!      (radix(1_i8)**(digits(1_i8) - 1))*(4/3).
+!     In summary, this shows that no absolute value generated during
+!     this process will exceed the maximum value representable in i8,
+!     i.e. (radix(1_i8)**(digits(1_i8)) - 1), as long as
+!     digits(1_i8) >= 2. 
+! (b) 'ilevel==0,...,-(extra_levels-1)' correspond to extra levels
+!     used to continue the above process until values at all levels
+!     are less than radix(1_i8)**arr_max_shift in absolute value
+!     (except level -(extra_levels-1), as described below). The
+!     result of shifting the overlap from level 1 to level 0, which
+!     is initially zero, is bounded in absolute value by 
+!      (radix(1_i8)**(digits(1_i8) - 1 - arr_max_shift))*(4/3).
+!     After removing any overlap from level 0, the upper bound for
+!     level -1, which is also initially zero, is
+!      (radix(1_i8)**(digits(1_i8) - 1 - 2*arr_max_shift))*(4/3).
+!     Continuing the process, when get to level -(extra_levels-1),
+!     the upper bound is
+!      (radix(1_i8)**(digits(1_i8) - 1 - extra_levels*arr_max_shift))*(4/3).
+!     If we define
+!      extra_levels = ceiling[(digits(1_i8) - 1)/arr_max_shift - 1]
+!     then the upper bound is
+!      (radix(1_i8)**(arr_max_shift))*(4/3).
+!     Setting 
+!      extra_levels = (digits(1_i8) - 1)/arr_max_shift
+!     is then a slightly conservative estimate that achieves the same
+!     upper bound. While the above upper bound at level
+!     -(extra_levels-1)is a factor of (4/3) larger than the target
+!     radix(1_i8)**arr_max_shift, it is still small enough so that
+!     the sum over threads and tasks, bounded from above in absolute
+!     value by 
+!      (radix(1_i8)**(digits(1_i8) - 1))*(4/3),
+!     will not cause an overflow at level -(extra_levels-1) as long as
+!     digits(1_i8) >= 2.
+          do ilevel=max_levels(ifld),min_level+1,-1
+             if (abs(i8_arr_tlsum_level(ilevel,ifld,ithread)) >= &
+                    (i8_radix**arr_max_shift)) then
+                
+                IX_8 = i8_arr_tlsum_level(ilevel,ifld,ithread) &
+                       / (i8_radix**arr_max_shift)
                 i8_arr_tlsum_level(ilevel-1,ifld,ithread) = &
                    i8_arr_tlsum_level(ilevel-1,ifld,ithread) + IX_8
+                
                 IX_8 = IX_8*(i8_radix**arr_max_shift)
                 i8_arr_tlsum_level(ilevel,ifld,ithread)   = &
                    i8_arr_tlsum_level(ilevel,ifld,ithread) - IX_8
@@ -1299,7 +1408,7 @@ module shr_reprosum_mod
       do ifld=1,nflds
          ioffset = offset(ifld)
          do ithread = 1,omp_nthreads
-            do ilevel = 0,max_levels(ifld)
+            do ilevel = min_level,max_levels(ifld)
                i8_arr_lsum_level(ioffset+ilevel) = &
                   i8_arr_lsum_level(ioffset+ilevel) &
                   + i8_arr_tlsum_level(ilevel,ifld,ithread)
@@ -1372,29 +1481,67 @@ module shr_reprosum_mod
          if (.not. recompute) then
 
 ! Preprocess integer vector:
-!  a) If value larger than or equal to (radix(IX_8)**arr_max_shift), add this 'overlap'
-!     to next larger integer in vector, resulting in nonoverlapping ranges for each
-!     component. Note that have 'ilevel-1=0' level here as described above.
-           do ilevel=max_levels(ifld),1,-1
-             RX_8 = i8_arr_gsum_level(ioffset+ilevel)
-             IX_8 = int(scale(RX_8,-arr_max_shift),i8)
-             if (IX_8 /= 0_i8) then
-               i8_arr_gsum_level(ioffset+ilevel-1) = i8_arr_gsum_level(ioffset+ilevel-1) &
-                                                   + IX_8
-               IX_8 = IX_8*(i8_radix**arr_max_shift)
-               i8_arr_gsum_level(ioffset+ilevel)   = i8_arr_gsum_level(ioffset+ilevel)   &
-                                                   - IX_8
-             endif
+!  a) If value larger than or equal to (radix(1_i8)**arr_max_shift),
+!     add this 'overlap' to the value at the next smaller level
+!     in the vector, resulting in nonoverlapping ranges for each
+!     component.
+!
+!     As before, no intermediate sums for levels
+!     max_levels(ifld) to -(extra_levels-2), in absolute value,
+!     will exceed the the maximum value representable in i8, but the
+!     upper bound on the final sum, in absolute value, at
+!     level -(extra_levels-1) is now 
+!      (radix(1_i8)**(digits(1_i8) - 1))*(4/3) + 
+!            + sum{i=1,inf}(radix(1_i8)**(-i*arr_max_shift))
+!      = (radix(1_i8)**(digits(1_i8) - 1))*
+!            ((4/3) + sum{i=1,inf}(radix(1_i8)**(-i*arr_max_shift)).
+!     which is less than or equal to 
+!      (radix(1_i8)**(digits(1_i8) - 1))*((4/3) + (1/3))
+!     or
+!      (radix(1_i8)**(digits(1_i8) - 1))*(5/3)
+!     which will not cause an overflow at level -(extra_levels-1)
+!     as long as digits(1_i8) >= 3.
+!
+!     Since the exponents associated with each successive level
+!     differ by arr_max_shift, monotonically decreasing with
+!     increasing level, the absolute value at each level after this
+!     preprocessing is strictly less than what can be represented at
+!     the next lower level (larger exponent). If nonzero, it is also
+!     strictly greater than what is represented at the next higher
+!     level (smaller exponent). Note that the smallest level,
+!     -(extra_levels-1), does not have to be less than
+!     (radix(1_i8)**arr_max_shift) for this 'nonoverlap' property to
+!     hold. 
+           do ilevel=max_levels(ifld),min_level+1,-1
+              if (abs(i8_arr_gsum_level(ioffset+ilevel)) >= &
+                     (i8_radix**arr_max_shift)) then
+
+                  IX_8 = i8_arr_gsum_level(ioffset+ilevel) &
+                         / (i8_radix**arr_max_shift)
+                  i8_arr_gsum_level(ioffset+ilevel-1) = &
+                     i8_arr_gsum_level(ioffset+ilevel-1) + IX_8
+
+                  IX_8 = IX_8*(i8_radix**arr_max_shift)
+                  i8_arr_gsum_level(ioffset+ilevel)   = &
+                     i8_arr_gsum_level(ioffset+ilevel) - IX_8
+              endif
            enddo
-!  b) Working consecutively from first level with a nonzero value up
-!     to level max_levels(ifld), subtract +/- 1 from level with larger
-!     exponent (e.g., ilevel) and add  +/- (i8_radix**arr_max_shift)
-!     to level with smaller exponent (ilevel+1) when necessary so that
-!     all vector components have the same sign. Treat a zero value at
-!     ilevel+1 as always a different sign from value at ilevel so that
-!     process always makes this nonzero. (Otherwise, the wrong sign
-!     could be reintroduced by subtracting from a zero value at the
-!     next step.)  
+!  b) Working consecutively from the first level with a nonzero value
+!     up to level max_levels(ifld), subtract +/- 1 from level with
+!     larger exponent (e.g., ilevel) and add  +/-
+!     (i8_radix**arr_max_shift) to level with smaller exponent
+!     (ilevel+1), when necessary, so that the value at ilevel+1
+!     has the same sign as the value at ilevel. Treat a zero value at
+!     ilevel+1 as always a different sign from the value at ilevel so
+!     that the process always makes this nonzero. (Otherwise, the
+!     wrong sign could be reintroduced by subtracting from a zero
+!     value at the next step.) When finished with the process values
+!     at all levels are either greater than or equal to zero or all
+!     are less than or equal to zero. Note that this can decrease (but
+!     not increase) the absolute value at level -(extra_levels-1) by
+!     1. All other levels are now less than or equal to
+!     (radix(1_i8)**arr_max_shift) in absolute value rather than
+!     strictly less than. 
            ilevel = 0
            do while ((i8_arr_gsum_level(ioffset+ilevel) == 0_i8) &
                      .and. (ilevel < max_levels(ifld)))

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -182,7 +182,7 @@ module shr_reprosum_mod
               'Will abort if INF or NaN are included in summands'
          endif
 
-         if (shr_reprosum_reldiffmax >= 0._r8) then
+         if (shr_reprosum_reldiffmax >= 0.0_r8) then
             write(logunit,*) '                    ',&
               'with a maximum relative error tolerance of ', &
               shr_reprosum_reldiffmax
@@ -665,7 +665,7 @@ module shr_reprosum_mod
 ! check whether intrinsic-based algorithm will work on this system
 ! (requires floating point and integer bases to be the same)
 ! If not, always use ddpdd.
-      use_ddpdd_sum = use_ddpdd_sum .or. (radix(0._r8) /= radix(0_i8))
+      use_ddpdd_sum = use_ddpdd_sum .or. (radix(1.0_r8) /= radix(1_i8))
 
       if ( use_ddpdd_sum ) then
 #ifdef TIMING
@@ -751,13 +751,13 @@ module shr_reprosum_mod
 ! A 'max' is used in the above calculation because the partial sum for
 ! each thread, calculated in shr_reprosum_int, is postprocessed so that
 ! each integer in the corresponding vector of integers is reduced in
-! magnitude to be less than (radix(IX_8)**arr_max_shift). Therefore,
+! magnitude to be less than (radix(1_i8)**arr_max_shift). Therefore,
 ! the maximum shift can be calculated separately for per thread sums
 ! and sums over threads and tasks, and the smaller value used. This is
 ! equivalent to using max_nsummands as defined above.
 
                xmax_nsummands = dble(max_nsummands)
-               arr_max_shift = digits(0_i8) - (exponent(xmax_nsummands) + 1)
+               arr_max_shift = digits(1_i8) - (exponent(xmax_nsummands) + 1)
                if (arr_max_shift < 2) then
                   call shr_sys_abort('repro_sum failed: number of summands too '// &
                                      'large for integer vector algorithm' )
@@ -821,8 +821,8 @@ module shr_reprosum_mod
                call t_startf('repro_sum_loopa')
 #endif
                do ifld=1,nflds
-                  arr_exp_tlmin = MAXEXPONENT(1._r8)
-                  arr_exp_tlmax = MINEXPONENT(1._r8)
+                  arr_exp_tlmin = MAXEXPONENT(1.0_r8)
+                  arr_exp_tlmax = MINEXPONENT(1.0_r8)
                   if (.not. arr_gsum_infnan(ifld)) then
                      do isum=isum_beg(ithread),isum_end(ithread)
                         if (arr(isum,ifld) .ne. 0.0_r8) then
@@ -891,13 +891,13 @@ module shr_reprosum_mod
 ! A 'max' is used in the above calculation because the partial sum for
 ! each thread, calculated in shr_reprosum_int, is postprocessed so that
 ! each integer in the corresponding vector of integers is reduced in
-! magnitude to be less than (radix(IX_8)**arr_max_shift). Therefore,
+! magnitude to be less than (radix(1_i8)**arr_max_shift). Therefore,
 ! the maximum shift can be calculated separately for per thread sums
 ! and sums over threads and tasks, and the smaller value used. This is
 ! equivalent to using max_nsummands as defined above.
 
             xmax_nsummands = dble(max_nsummands)
-            arr_max_shift = digits(0_i8) - (exponent(xmax_nsummands) + 1)
+            arr_max_shift = digits(1_i8) - (exponent(xmax_nsummands) + 1)
             if (arr_max_shift < 2) then
                call shr_sys_abort('repro_sum failed: number of summands too '// &
                                   'large for integer vector algorithm' )
@@ -922,7 +922,7 @@ module shr_reprosum_mod
             max_level = (64/nflds) + 1
             do ifld=1,nflds
                max_levels(ifld) = 2 + &
-                ((digits(0.0_r8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) &
+                ((digits(1.0_r8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) &
                 / arr_max_shift)
                if ( present(arr_max_levels) .and. (.not. validate) ) then
 ! if validate true, then computation with arr_max_levels failed
@@ -966,7 +966,7 @@ module shr_reprosum_mod
 ! record statistic
             nonrepro_sum = 1
 ! compute nonreproducible sum
-            arr_lsum(:) = 0._r8
+            arr_lsum(:) = 0.0_r8
 !$omp parallel do      &
 !$omp default(shared)  &
 !$omp private(ifld, isum)
@@ -1098,7 +1098,7 @@ module shr_reprosum_mod
 ! Local workspace
 !
       integer, parameter  :: max_jlevel = &
-                                1 + (digits(0_i8)/digits(0.0_r8))
+                                1 + (digits(1_i8)/digits(1.0_r8))
 
       integer(i8) :: i8_arr_tlsum_level(0:max_level,nflds,omp_nthreads)
                                    ! integer vector representing local
@@ -1465,12 +1465,12 @@ module shr_reprosum_mod
 ! apply final exponent correction, scaling first if exponent is too small
 ! to apply directly
             corr_exp = curr_exp + exponent(arr_gsum(ifld))
-            if (corr_exp .ge. MINEXPONENT(1._r8)) then
+            if (corr_exp .ge. MINEXPONENT(1.0_r8)) then
                arr_gsum(ifld) = set_exponent(arr_gsum(ifld),corr_exp)
             else
                RX_8 = set_exponent(arr_gsum(ifld), &
-                                   corr_exp-MINEXPONENT(1._r8))
-               arr_gsum(ifld) = scale(RX_8,MINEXPONENT(1._r8))
+                                   corr_exp-MINEXPONENT(1.0_r8))
+               arr_gsum(ifld) = scale(RX_8,MINEXPONENT(1.0_r8))
             endif
 
 ! if validate is .true. and some precision lost, test whether 'too much'

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -1158,6 +1158,9 @@ module shr_reprosum_mod
 !
 ! Local workspace
 !
+      integer, parameter  :: max_svlevel_factor = &
+                                1 + (digits(1_i8)/digits(1.0_r8))
+
       integer(i8) :: i8_arr_tlsum_level(-(extra_levels-1):max_level,nflds,omp_nthreads)
                                    ! integer vector representing local
                                    !  sum (per thread, per field)
@@ -1233,7 +1236,7 @@ module shr_reprosum_mod
                                    !  i8_arr_gsum_level
       real(r8) :: RX_8             ! r8 representation of (other)
                                    !  integers used in calculation.
-      real(r8) :: summand_vector(max_level)
+      real(r8) :: summand_vector((max_level+extra_levels)*max_svlevel_factor)
                                    ! vector of r8 values generated from
                                    !  integer vector representation to be
                                    !  summed to generate global sum

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -1386,10 +1386,15 @@ module shr_reprosum_mod
                                                    - IX_8
              endif
            enddo
-!  b) Subtract +/- 1 from larger and add +/- 1 to smaller when necessary
-!     so that all vector components have the same sign (eliminating loss
-!     of accuracy arising from difference of large values when
-!     reconstructing r8 sum from integer vector)
+!  b) Working consecutively from first level with a nonzero value up
+!     to level max_levels(ifld), subtract +/- 1 from level with larger
+!     exponent (e.g., ilevel) and add  +/- (i8_radix**arr_max_shift)
+!     to level with smaller exponent (ilevel+1) when necessary so that
+!     all vector components have the same sign. Treat a zero value at
+!     ilevel+1 as always a different sign from value at ilevel so that
+!     process always makes this nonzero. (Otherwise, the wrong sign
+!     could be reintroduced by subtracting from a zero value at the
+!     next step.)  
            ilevel = 0
            do while ((i8_arr_gsum_level(ioffset+ilevel) == 0_i8) &
                      .and. (ilevel < max_levels(ifld)))
@@ -1403,12 +1408,14 @@ module shr_reprosum_mod
                  i8_sign = -1_i8
               endif
               do jlevel=ilevel,max_levels(ifld)-1
-                 if (sign(1_i8,i8_arr_gsum_level(ioffset+jlevel)) &
-                     /= sign(1_i8,i8_arr_gsum_level(ioffset+jlevel+1))) then
-                    i8_arr_gsum_level(ioffset+jlevel)   = i8_arr_gsum_level(ioffset+jlevel) &
-                                                        - i8_sign
-                    i8_arr_gsum_level(ioffset+jlevel+1) = i8_arr_gsum_level(ioffset+jlevel+1) &
-                                                        + i8_sign*(i8_radix**arr_max_shift)
+                 if ((sign(1_i8,i8_arr_gsum_level(ioffset+jlevel)) &
+                      /= sign(1_i8,i8_arr_gsum_level(ioffset+jlevel+1))) &
+                     .or. (i8_arr_gsum_level(ioffset+jlevel+1) == 0_i8)) then
+                    i8_arr_gsum_level(ioffset+jlevel)   = &
+                       i8_arr_gsum_level(ioffset+jlevel) - i8_sign
+                    i8_arr_gsum_level(ioffset+jlevel+1) = &
+                       i8_arr_gsum_level(ioffset+jlevel+1) &
+                       + i8_sign*(i8_radix**arr_max_shift)
                  endif
               enddo
             endif

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -1542,7 +1542,7 @@ module shr_reprosum_mod
 !     1. All other levels are now less than or equal to
 !     (radix(1_i8)**arr_max_shift) in absolute value rather than
 !     strictly less than. 
-           ilevel = 0
+           ilevel = min_level
            do while ((i8_arr_gsum_level(ioffset+ilevel) == 0_i8) &
                      .and. (ilevel < max_levels(ifld)))
              ilevel = ilevel + 1
@@ -1572,7 +1572,7 @@ module shr_reprosum_mod
                         - max_levels(ifld)*arr_max_shift
             curr_exp = 0
             first = .true.
-            do ilevel=max_levels(ifld),0,-1
+            do ilevel=max_levels(ifld),min_level,-1
 
                if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
                   jlevel = 1
@@ -1637,7 +1637,7 @@ module shr_reprosum_mod
 ! Find first nonzero level and use exponent for this level, then assume all
 ! subsequent levels contribute arr_max_shift digits.
                   sum_digits = 0
-                  do ilevel=0,max_levels(ifld)
+                  do ilevel=min_level,max_levels(ifld)
                      if (sum_digits == 0) then
                         if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
                            X_8(1) = i8_arr_gsum_level(ioffset+ilevel)

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -1,5 +1,5 @@
 module shr_reprosum_mod
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Compute reproducible global sums of a set of arrays across an MPI
@@ -26,11 +26,11 @@ module shr_reprosum_mod
 !                    vector algorithm and on He/Ding paper for DDPDD
 !                    algorithm)
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 
-!-----------------------------------------------------------------------
-!- use statements ------------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
+!- use statements -------------------------------------------------------
+!------------------------------------------------------------------------
 #if ( defined noI8 )
    ! Workaround for when shr_kind_i8 is not supported.
    use shr_kind_mod,  only: r8 => shr_kind_r8, i8 => shr_kind_i4
@@ -48,49 +48,49 @@ module shr_reprosum_mod
 #ifdef TIMING
    use perf_mod
 #endif
-!-----------------------------------------------------------------------
-!- module boilerplate --------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
+!- module boilerplate ---------------------------------------------------
+!------------------------------------------------------------------------
    implicit none
    private
 
-!-----------------------------------------------------------------------
-!- include statements --------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
+!- include statements ---------------------------------------------------
+!------------------------------------------------------------------------
 #include <mpif.h>
 
    save
 
-!-----------------------------------------------------------------------
-! Public interfaces ----------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
+! Public interfaces -----------------------------------------------------
+!------------------------------------------------------------------------
    public :: &
       shr_reprosum_setopts,        &! set runtime options
       shr_reprosum_calc,           &! calculate distributed sum
       shr_reprosum_tolExceeded      ! utility function to check relative
                                     !  differences against the tolerance
 
-!-----------------------------------------------------------------------
-! Public data ----------------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
+! Public data -----------------------------------------------------------
+!------------------------------------------------------------------------
    logical, public     :: shr_reprosum_recompute = .false.
 
    real(r8), public    :: shr_reprosum_reldiffmax = -1.0_r8
 
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 ! Private interfaces ----------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
    private :: &
       ddpdd,           &! double-double sum routine
       split_indices     ! split indices among OMP threads
 
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 ! Private data ----------------------------------------------------------
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 
-   !----------------------------------------------------------------------------
+   !---------------------------------------------------------------------
    ! shr_reprosum_mod options
-   !----------------------------------------------------------------------------
+   !---------------------------------------------------------------------
    logical            :: repro_sum_use_ddpdd = .false.
 
    logical            :: repro_sum_allow_infnan = .false.
@@ -107,11 +107,11 @@ module shr_reprosum_mod
                                    repro_sum_master,          &
                                    repro_sum_logunit          )
 
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 ! Purpose: Set runtime options
 ! Author: P. Worley
-!-----------------------------------------------------------------------
-!------------------------------Arguments--------------------------------
+!------------------------------------------------------------------------
+!------------------------------Arguments---------------------------------
       ! Use DDPDD algorithm instead of integer vector algorithm
       logical, intent(in), optional :: repro_sum_use_ddpdd_in
       ! Allow INF or NaN in summands
@@ -127,11 +127,11 @@ module shr_reprosum_mod
       logical, intent(in), optional  :: repro_sum_master
       ! unit number for log messages
       integer, intent(in), optional  :: repro_sum_logunit
-!---------------------------Local Workspace-----------------------------
+!---------------------------Local Workspace------------------------------
       integer logunit            ! unit number for log messages
       logical master             ! local master?
       logical,save :: firstcall = .true.  ! first call
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 
       if ( present(repro_sum_master) ) then
          master = repro_sum_master
@@ -214,7 +214,7 @@ module shr_reprosum_mod
                                  gbl_max_nsummands, gbl_max_nsummands_out,&
                                  gbl_count, repro_sum_validate,           &
                                  repro_sum_stats, rel_diff, commid        )
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Compute the global sum of each field in 'arr' using the indicated
@@ -428,7 +428,7 @@ module shr_reprosum_mod
 ! set to .true. It is also used if the integer vector algorithm radix
 ! assumption does not hold.
 !
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Arguments
 !
@@ -576,9 +576,9 @@ module shr_reprosum_mod
       external omp_get_max_threads
 #endif
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
-! initialize local statistics variables
+! Initialize local statistics variables
       gbl_lor_red = 0
       gbl_max_red = 0
       repro_sum_fast = 0
@@ -586,7 +586,7 @@ module shr_reprosum_mod
       repro_sum_both = 0
       nonrepro_sum = 0
 
-! set MPI communicator
+! Set MPI communicator
       if ( present(commid) ) then
          mpi_comm = commid
       else
@@ -595,7 +595,7 @@ module shr_reprosum_mod
 #ifdef TIMING
       call t_barrierf('sync_repro_sum',mpi_comm)
 #endif
-! check whether should abort if input contains NaNs or INFs
+! Check whether should abort if input contains NaNs or INFs
       abort_inf_nan = .not. repro_sum_allow_infnan
       if ( present(allow_infnan) ) then
          abort_inf_nan = .not. allow_infnan
@@ -603,13 +603,13 @@ module shr_reprosum_mod
 #ifdef TIMING
       call t_startf('shr_reprosum_INF_NaN_Chk')
 #endif
-! initialize flags to indicate that no NaNs or INFs are present in the input data
+! Initialize flags to indicate that no NaNs or INFs are present in the input data
       inf_nan_gchecks = .false.
       arr_gsum_infnan = .false.
 
       if (abort_inf_nan) then
 
-! check whether input contains NaNs or INFs, and abort if so
+! Check whether input contains NaNs or INFs, and abort if so
          nan_check = any(shr_infnan_isnan(arr))
          inf_check = any(shr_infnan_isinf(arr))
 
@@ -630,7 +630,7 @@ module shr_reprosum_mod
 
       else
 
-! determine whether any fields contain NaNs or INFs, and avoid processing them
+! Determine whether any fields contain NaNs or INFs, and avoid processing them
 ! via integer expansions
          inf_nan_lchecks = .false.
 
@@ -656,13 +656,13 @@ module shr_reprosum_mod
 #ifdef TIMING
       call t_stopf('shr_reprosum_INF_NaN_Chk')
 #endif
-! check whether should use shr_reprosum_ddpdd algorithm
+! Check whether should use shr_reprosum_ddpdd algorithm
       use_ddpdd_sum = repro_sum_use_ddpdd
       if ( present(ddpdd_sum) ) then
          use_ddpdd_sum = ddpdd_sum
       endif
 
-! check whether intrinsic-based algorithm will work on this system
+! Check whether intrinsic-based algorithm will work on this system
 ! (requires floating point and integer bases to be the same)
 ! If not, always use ddpdd.
       use_ddpdd_sum = use_ddpdd_sum .or. (radix(1.0_r8) /= radix(1_i8))
@@ -681,23 +681,23 @@ module shr_reprosum_mod
 #ifdef TIMING
          call t_startf('shr_reprosum_int')
 #endif
-! get number of MPI tasks
+! Get number of MPI tasks
          call mpi_comm_size(mpi_comm, tasks, ierr)
 
-! get number of OpenMP threads
+! Get number of OpenMP threads
 #ifdef _OPENMP
          omp_nthreads = omp_get_max_threads()
 #else
          omp_nthreads = 1
 #endif
 
-! see if have sufficient information to not require max/min allreduce
+! See if have sufficient information to not require max/min allreduce
          recompute = .true.
          validate = .false.
          if ( present(arr_gbl_max) .and. present(arr_max_levels) ) then
             recompute = .false.
 
-! setting lower bound on max_level*nflds to be 64 to improve OpenMP
+! Setting lower bound on max_level*nflds to be 64 to improve OpenMP
 ! performance for loopb in shr_reprosum_int
             max_level = (64/nflds) + 1
             do ifld=1,nflds
@@ -715,7 +715,7 @@ module shr_reprosum_mod
 
             if (.not. recompute) then
 
-! determine maximum number of summands in local phases of the
+! Determine maximum number of summands in local phases of the
 ! algorithm
 #ifdef TIMING
                call t_startf("repro_sum_allr_max")
@@ -736,15 +736,15 @@ module shr_reprosum_mod
 #ifdef TIMING
                call t_stopf("repro_sum_allr_max")
 #endif
-! determine maximum shift. Shift needs to be small enough that summation
-!  does not exceed maximum number of digits in i8.
+! Determine maximum shift. Shift needs to be small enough that summation
+! does not exceed maximum number of digits in i8.
 
-! if requested, return max_nsummands before it is redefined
+! If requested, return max_nsummands before it is redefined
                if ( present( gbl_max_nsummands_out) ) then
                   gbl_max_nsummands_out = max_nsummands
                endif
 
-! summing within each thread first
+! Summing within each thread first
                max_nsummands = (max_nsummands/omp_nthreads) + 1
 ! then over threads and tasks
                max_nsummands = max(max_nsummands, tasks*omp_nthreads)
@@ -763,7 +763,7 @@ module shr_reprosum_mod
                                      'large for integer vector algorithm' )
                endif
 
-! calculate sum
+! Calculate sum
                if (present(repro_sum_validate)) then
                   validate = repro_sum_validate
                else
@@ -774,12 +774,12 @@ module shr_reprosum_mod
                                      arr_max_levels, max_level, arr_gsum_infnan, &
                                      validate, recompute, omp_nthreads, mpi_comm)
 
-! record statistics, etc.
+! Record statistics, etc.
                repro_sum_fast = 1
                if (recompute) then
                   repro_sum_both = 1
                else
-! if requested, return specified levels and upper bounds on maxima
+! If requested, return specified levels and upper bounds on maxima
                   if ( present(arr_max_levels_out) ) then
                      do ifld=1,nflds
                         arr_max_levels_out(ifld) = arr_max_levels(ifld)
@@ -794,23 +794,23 @@ module shr_reprosum_mod
             endif
          endif
 
-! do not have sufficient information; calculate global max/min and
+! Do not have sufficient information; calculate global max/min and
 ! use to compute required number of levels
          if (recompute) then
 
-! record statistic
+! Record statistic
             repro_sum_slow = 1
 
-! determine maximum and minimum (non-zero) summand values and
+! Determine maximum and minimum (non-zero) summand values and
 ! maximum number of local summands
 
-! allocate thread-specific work space
+! Allocate thread-specific work space
             allocate(arr_tlmax_exp(nflds,omp_nthreads))
             allocate(arr_tlmin_exp(nflds,omp_nthreads))
             allocate(isum_beg(omp_nthreads))
             allocate(isum_end(omp_nthreads))
 
-! split summand index range over OpenMP threads
+! Split summand index range over OpenMP threads
             call split_indices(nsummands, omp_nthreads, isum_beg, isum_end)
 
 !$omp parallel do      &
@@ -861,30 +861,30 @@ module shr_reprosum_mod
             arr_gmax_exp(:) = -arr_gextremes(1:nflds,1)
             arr_gmin_exp(:) =  arr_gextremes(1:nflds,2)
 
-! if a field is identically zero or contains INFs or NaNs, arr_gmin_exp
-!   still equals MAXEXPONENT and arr_gmax_exp still equals MINEXPONENT.
-!   In this case, set arr_gmin_exp = arr_gmax_exp = MINEXPONENT
+! If a field is identically zero or contains INFs or NaNs, arr_gmin_exp
+! still equals MAXEXPONENT and arr_gmax_exp still equals MINEXPONENT.
+! In this case, set arr_gmin_exp = arr_gmax_exp = MINEXPONENT
             do ifld=1,nflds
                arr_gmin_exp(ifld) = min(arr_gmax_exp(ifld),arr_gmin_exp(ifld))
             enddo
 
-! if requested, return upper bounds on observed maxima
+! If requested, return upper bounds on observed maxima
             if ( present(arr_gbl_max_out) ) then
                do ifld=1,nflds
                   arr_gbl_max_out(ifld) = scale(1.0_r8,arr_gmax_exp(ifld))
                enddo
             endif
 
-! if requested, return max_nsummands before it is redefined
+! If requested, return max_nsummands before it is redefined
             if ( present( gbl_max_nsummands_out) ) then
                gbl_max_nsummands_out = max_nsummands
             endif
 
-! determine maximum shift (same as in previous branch, but with calculated
-!  max_nsummands). Shift needs to be small enough that summation does not
-!  exceed maximum number of digits in i8.
+! Determine maximum shift (same as in previous branch, but with calculated
+! max_nsummands). Shift needs to be small enough that summation does not
+! exceed maximum number of digits in i8.
 
-! summing within each thread first
+! Summing within each thread first
             max_nsummands = (max_nsummands/omp_nthreads) + 1
 ! then over threads and tasks
             max_nsummands = max(max_nsummands, tasks*omp_nthreads)
@@ -925,8 +925,8 @@ module shr_reprosum_mod
                 ((digits(1.0_r8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) &
                 / arr_max_shift)
                if ( present(arr_max_levels) .and. (.not. validate) ) then
-! if validate true, then computation with arr_max_levels failed
-!  previously
+! If validate true, then computation with arr_max_levels failed
+! previously
                   if ( arr_max_levels(ifld) > 0 ) then
                      max_levels(ifld) = &
                         min(arr_max_levels(ifld),max_levels(ifld))
@@ -936,14 +936,14 @@ module shr_reprosum_mod
                   max_level = max_levels(ifld)
             enddo
 
-! if requested, return calculated levels
+! If requested, return calculated levels
             if ( present(arr_max_levels_out) ) then
                do ifld=1,nflds
                   arr_max_levels_out(ifld) = max_levels(ifld)
                enddo
             endif
 
-! calculate sum
+! Calculate sum
             validate = .false.
             call shr_reprosum_int(arr, arr_gsum, nsummands, dsummands, &
                                   nflds, arr_max_shift, arr_gmax_exp, &
@@ -956,16 +956,16 @@ module shr_reprosum_mod
 #endif
       endif
 
-! compare integer vector and floating point results
+! Compare integer vector and floating point results
       if ( present(rel_diff) ) then
          if (shr_reprosum_reldiffmax >= 0.0_r8) then
 #ifdef TIMING
             call t_barrierf('sync_nonrepro_sum',mpi_comm)
             call t_startf('nonrepro_sum')
 #endif
-! record statistic
+! Record statistic
             nonrepro_sum = 1
-! compute nonreproducible sum
+! Compute nonreproducible sum
             arr_lsum(:) = 0.0_r8
 !$omp parallel do      &
 !$omp default(shared)  &
@@ -987,7 +987,7 @@ module shr_reprosum_mod
 
             call t_stopf('nonrepro_sum')
 #endif
-! determine differences
+! Determine differences
 !$omp parallel do      &
 !$omp default(shared)  &
 !$omp private(ifld, abs_diff)
@@ -1024,7 +1024,7 @@ module shr_reprosum_mod
          endif
       end do
 
-! return statistics
+! Return statistics
       if ( present(repro_sum_stats) ) then
          repro_sum_stats(1) = repro_sum_stats(1) + repro_sum_fast
          repro_sum_stats(2) = repro_sum_stats(2) + repro_sum_slow
@@ -1044,7 +1044,7 @@ module shr_reprosum_mod
                                 arr_max_shift, arr_gmax_exp, max_levels,    &
                                 max_level, skip_field, validate, recompute, &
                                 omp_nthreads, mpi_comm                      )
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Compute the global sum of each field in 'arr' using the indicated
@@ -1056,7 +1056,7 @@ module shr_reprosum_mod
 ! controlled by the number of 'levels' of integer expansion, the maximum
 ! value of which is specified by max_level.
 !
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Arguments
 !
@@ -1166,7 +1166,7 @@ module shr_reprosum_mod
                                    !  from integer vector
 
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 ! Save radix of i8 variables in an i8 variable
       i8_radix = radix(IX_8)
 
@@ -1178,7 +1178,7 @@ module shr_reprosum_mod
         voffset = 1
       endif
 
-! compute offsets for each field
+! Compute offsets for each field
       offset(1) = voffset
       do ifld=2,nflds
          offset(ifld) = offset(ifld-1) &
@@ -1186,12 +1186,12 @@ module shr_reprosum_mod
       enddo
       veclth = offset(nflds) + max_levels(nflds)
 
-! split summand index range over OpenMP threads
+! Split summand index range over OpenMP threads
       call split_indices(nsummands, omp_nthreads, isum_beg, isum_end)
 
-! convert local summands to vector of integers and sum
+! Convert local summands to vector of integers and sum
 ! (Using scale instead of set_exponent because arr_remainder may not be
-!  'normal' after level 1 calculation)
+! 'normal' after level 1 calculation)
       i8_arr_lsum_level(:) = 0_i8
 
 !$omp parallel do      &
@@ -1218,18 +1218,18 @@ module shr_reprosum_mod
                arr_exp   = exponent(arr(isum,ifld))
                arr_frac  = fraction(arr(isum,ifld))
 
-! test that global maximum upper bound is an upper bound
+! Test that global maximum upper bound is an upper bound
                if (arr_exp > arr_gmax_exp(ifld)) then
                   max_error(ifld,ithread) = 1
                   exit
                endif
 
-! calculate first shift
+! Calculate first shift
                arr_shift = arr_max_shift - (arr_gmax_exp(ifld)-arr_exp)
 
-! determine first (probably) nonzero level (assuming initial fraction is
-!  'normal' - algorithm still works if this is not true)
-!  NOTE: this is critical; scale will set to zero if min exponent is too small.
+! Determine first (probably) nonzero level (assuming initial fraction is
+! 'normal' - algorithm still works if this is not true)
+! NOTE: this is critical; scale will set to zero if min exponent is too small.
                if (arr_shift < 1) then
                   ilevel = (1 + (arr_gmax_exp(ifld)-arr_exp))/arr_max_shift
                   arr_shift = ilevel*arr_max_shift - (arr_gmax_exp(ifld)-arr_exp)
@@ -1243,7 +1243,7 @@ module shr_reprosum_mod
                endif
 
                if (ilevel <= max_levels(ifld)) then
-! apply first shift/truncate, add it to the relevant running
+! Apply first shift/truncate, add it to the relevant running
 ! sum, and calculate the remainder.
                   arr_remainder = scale(arr_frac,arr_shift)
                   i8_arr_level = int(arr_remainder,i8)
@@ -1251,7 +1251,7 @@ module shr_reprosum_mod
                      i8_arr_tlsum_level(ilevel,ifld,ithread) + i8_arr_level
                   arr_remainder = arr_remainder - i8_arr_level
 
-! while the remainder is non-zero, continue to shift, truncate,
+! While the remainder is non-zero, continue to shift, truncate,
 ! sum, and calculate new remainder
                   do while ((arr_remainder /= 0.0_r8) &
                      .and. (ilevel < max_levels(ifld)))
@@ -1272,7 +1272,7 @@ module shr_reprosum_mod
 
           enddo
 
-! postprocess integer vector to eliminate potential for overlap in the following
+! Postprocess integer vector to eliminate potential for overlap in the following
 ! sums over threads and MPI tasks: if value larger than or equal to
 ! (radix(IX_8)**arr_max_shift), add this 'overlap' to next larger integer in
 ! vector, resulting in nonoverlapping ranges for each component. Note that
@@ -1295,7 +1295,7 @@ module shr_reprosum_mod
 #endif
       enddo
 
-! sum contributions from different threads
+! Sum contributions from different threads
       do ifld=1,nflds
          ioffset = offset(ifld)
          do ithread = 1,omp_nthreads
@@ -1307,7 +1307,7 @@ module shr_reprosum_mod
          enddo
       enddo
 
-! record if upper bound was inaccurate or if level expansion stopped
+! Record if upper bound was inaccurate or if level expansion stopped
 ! before full accuracy was achieved
       if (validate) then
          do ifld=1,nflds
@@ -1317,7 +1317,7 @@ module shr_reprosum_mod
          enddo
       endif
 
-! sum integer vector element-wise
+! Sum integer vector element-wise
 #if ( defined noI8 )
      ! Workaround for when shr_kind_i8 is not supported.
 #ifdef TIMING
@@ -1343,12 +1343,12 @@ module shr_reprosum_mod
 !  1) arr_max_shift is the shift applied to fraction(arr_gmax) .
 !   When shifting back, need to 'add back in' true arr_gmax exponent. This was
 !   removed implicitly by working only with the fraction .
-!  2) want to add levels into sum in reverse order (smallest to largest). However,
+!  2) Want to add levels into sum in reverse order (smallest to largest). However,
 !   even this can generate floating point rounding errors if signs of integers
 !   alternate. To avoid this, do some arithmetic with integer vectors so that all
 !   components have the same sign. This should keep relative difference between
 !   using different integer sizes (e.g. i8 and i4) to machine epsilon
-!  3) assignment to X_8 will usually lose accuracy since maximum integer
+!  3) Assignment to X_8 will usually lose accuracy since maximum integer
 !   size is greater than the max number of 'digits' in r8 value (if xmax_nsummands
 !   correction not very large). Calculate remainder and add in first (since
 !   smaller). One correction is sufficient for r8 (53 digits) and i8 (63 digits).
@@ -1361,8 +1361,8 @@ module shr_reprosum_mod
          arr_gsum(ifld) = 0.0_r8
          ioffset = offset(ifld)
 
-! if validate is .true., test whether the summand upper bound
-!  was exceeded on any of the MPI tasks
+! If validate is .true., test whether the summand upper bound
+! was exceeded on any of the MPI tasks
          if (validate) then
             if (i8_arr_gsum_level(ioffset-voffset+1) /= 0_i8) then
                recompute = .true.
@@ -1371,8 +1371,8 @@ module shr_reprosum_mod
 
          if (.not. recompute) then
 
-! preprocess integer vector:
-!  a) if value larger than or equal to (radix(IX_8)**arr_max_shift), add this 'overlap'
+! Preprocess integer vector:
+!  a) If value larger than or equal to (radix(IX_8)**arr_max_shift), add this 'overlap'
 !     to next larger integer in vector, resulting in nonoverlapping ranges for each
 !     component. Note that have 'ilevel-1=0' level here as described above.
            do ilevel=max_levels(ifld),1,-1
@@ -1386,7 +1386,7 @@ module shr_reprosum_mod
                                                    - IX_8
              endif
            enddo
-!  b) subtract +/- 1 from larger and add +/- 1 to smaller when necessary
+!  b) Subtract +/- 1 from larger and add +/- 1 to smaller when necessary
 !     so that all vector components have the same sign (eliminating loss
 !     of accuracy arising from difference of large values when
 !     reconstructing r8 sum from integer vector)
@@ -1413,7 +1413,7 @@ module shr_reprosum_mod
               enddo
             endif
 
-! start with maximum shift, and work up to larger values
+! Start with maximum shift, and work up to larger values
             arr_shift = arr_gmax_exp(ifld) &
                         - max_levels(ifld)*arr_max_shift
             curr_exp = 0
@@ -1427,11 +1427,11 @@ module shr_reprosum_mod
                   X_8(jlevel) = i8_arr_gsum_level(ioffset+ilevel)
                   LX(jlevel)  = exponent(X_8(jlevel))
 
-! calculate remainder
+! Calculate remainder
                   IX_8 = int(X_8(jlevel),i8)
                   RX_8 = (i8_arr_gsum_level(ioffset+ilevel) - IX_8)
 
-! repeat using remainder
+! Repeat using remainder
                   do while (RX_8 /= 0.0_r8)
                      jlevel = jlevel + 1
                      X_8(jlevel) = RX_8
@@ -1440,7 +1440,7 @@ module shr_reprosum_mod
                      RX_8 = (i8_arr_gsum_level(ioffset+ilevel) - IX_8)
                   enddo
 
-! add in contributions, smaller to larger, rescaling for each
+! Add in contributions, smaller to larger, rescaling for each
 ! addition to guarantee that exponent of working summand is always
 ! larger than minexponent
                   do while (jlevel > 0)
@@ -1462,7 +1462,7 @@ module shr_reprosum_mod
                arr_shift = arr_shift + arr_max_shift
             enddo
 
-! apply final exponent correction, scaling first if exponent is too small
+! Apply final exponent correction, scaling first if exponent is too small
 ! to apply directly
             corr_exp = curr_exp + exponent(arr_gsum(ifld))
             if (corr_exp >= MINEXPONENT(1.0_r8)) then
@@ -1473,14 +1473,14 @@ module shr_reprosum_mod
                arr_gsum(ifld) = scale(RX_8,MINEXPONENT(1.0_r8))
             endif
 
-! if validate is .true. and some precision lost, test whether 'too much'
-!  was lost, due to too loose an upper bound, too stringent a limit on number
-!  of levels of expansion, cancellation, .... Calculated by comparing lower
-!  bound on number of sigificant digits with number of digits in 1.0_r8 .
+! If validate is .true. and some precision lost, test whether 'too much'
+! was lost, due to too loose an upper bound, too stringent a limit on number
+! of levels of expansion, cancellation, .... Calculated by comparing lower
+! bound on number of sigificant digits with number of digits in 1.0_r8 .
             if (validate) then
                if (i8_arr_gsum_level(ioffset-voffset+2) /= 0_i8) then
 
-! find first nonzero level and use exponent for this level, then assume all
+! Find first nonzero level and use exponent for this level, then assume all
 ! subsequent levels contribute arr_max_shift digits.
                   sum_digits = 0
                   do ilevel=0,max_levels(ifld)
@@ -1513,13 +1513,13 @@ module shr_reprosum_mod
 
    logical function shr_reprosum_tolExceeded (name, nflds, master, &
                                               logunit, rel_diff    )
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Test whether distributed sum exceeds tolerance and print out a
 ! warning message.
 !
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Arguments
 !
@@ -1546,7 +1546,7 @@ module shr_reprosum_mod
       real(r8) :: max_abs_diff                ! maximum absolute difference
       integer  :: max_abs_diff_idx            ! field index for max. abs. diff.
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
       shr_reprosum_tolExceeded = .false.
       if (shr_reprosum_reldiffmax < 0.0_r8) return
@@ -1557,7 +1557,7 @@ module shr_reprosum_mod
          llogunit = s_logunit
       endif
 
-      ! check that 'fast' reproducible sum is accurate enough.
+! Check that 'fast' reproducible sum is accurate enough.
       exceeds_limit = 0
       max_rel_diff = 0.0_r8
       max_abs_diff = 0.0_r8
@@ -1601,14 +1601,14 @@ module shr_reprosum_mod
 
    subroutine shr_reprosum_ddpdd (arr, arr_gsum, nsummands, dsummands,  &
                                   nflds, mpi_comm                       )
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Compute the global sum of each field in 'arr' using the indicated
 ! communicator with a reproducible yet scalable implementation based
 ! on He and Ding's implementation of the double-double algorithm.
 !
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Arguments
 !
@@ -1640,7 +1640,7 @@ module shr_reprosum_mod
       logical, save :: first_time = .true.
 
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
       call shr_reprosumx86_fix_start (old_cw)
 
@@ -1654,8 +1654,7 @@ module shr_reprosum_mod
 
          do isum=1,nsummands
 
-            ! Compute arr(isum,ifld) + arr_lsum_dd(ifld) using Knuth''s
-            ! trick.
+! Compute arr(isum,ifld) + arr_lsum_dd(ifld) using Knuth''s trick.
             t1 = arr(isum,ifld) + real(arr_lsum_dd(ifld))
             e  = t1 - arr(isum,ifld)
             t2 = ((real(arr_lsum_dd(ifld)) - e) &
@@ -1683,16 +1682,16 @@ module shr_reprosum_mod
 
    end subroutine shr_reprosum_ddpdd
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
    subroutine DDPDD (dda, ddb, len, itype)
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Modification of original codes written by David H. Bailey
 ! This subroutine computes ddb(i) = dda(i)+ddb(i)
 !
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Arguments
 !
@@ -1706,31 +1705,32 @@ module shr_reprosum_mod
       real(r8) e, t1, t2
       integer i
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
       do i = 1, len
-!   Compute dda + ddb using Knuth's trick.
+
+! Compute dda + ddb using Knuth's trick.
          t1 = real(dda(i)) + real(ddb(i))
          e  = t1 - real(dda(i))
          t2 = ((real(ddb(i)) - e) + (real(dda(i)) - (t1 - e))) &
               + aimag(dda(i)) + aimag(ddb(i))
 
-!   The result is t1 + t2, after normalization.
+! The result is t1 + t2, after normalization.
          ddb(i) = cmplx ( t1 + t2, t2 - ((t1 + t2) - t1), r8 )
       enddo
 
 
    end subroutine DDPDD
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
   subroutine split_indices(total,num_pieces,ibeg,iend)
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Purpose:
 ! Split range into 'num_pieces'
 !
-!----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
 ! Arguments
 !
@@ -1742,7 +1742,7 @@ module shr_reprosum_mod
 !
     integer :: itmp1, itmp2, ioffset, i
 !
-!-----------------------------------------------------------------------
+!------------------------------------------------------------------------
 !
     itmp1 = total/num_pieces
     itmp2 = mod(total,num_pieces)

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -1478,7 +1478,9 @@ module shr_reprosum_mod
 #endif
 #endif
 
+#ifdef TIMING
       call t_startf('repro_sum_finalsum')
+#endif
 ! Construct global sum from integer vector representation:
 !  1) arr_max_shift is the shift applied to fraction(arr_gmax) .
 !   When shifting back, need to 'add back in' the true arr_gmax exponent.
@@ -1852,7 +1854,9 @@ module shr_reprosum_mod
          endif
 
       enddo
+#ifdef TIMING
       call t_stopf('repro_sum_finalsum')
+#endif
 
    end subroutine shr_reprosum_int
 

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -226,7 +226,7 @@ module shr_reprosum_mod
 ! reproducible' floating point algorithm (DDPDD), as described below.
 !
 ! The accuracy of the integer vector algorithm is controlled by the
-! number of "levels" of integer expansion. The algorithm will calculate
+! number of 'levels' of integer expansion. The algorithm will calculate
 ! the number of levels that is required for the sum to be essentially
 ! exact. (The sum as represented by the integer expansion will be exact,
 ! but roundoff may perturb the least significant digit of the returned
@@ -1044,7 +1044,7 @@ module shr_reprosum_mod
 
 ! convert local summands to vector of integers and sum
 ! (Using scale instead of set_exponent because arr_remainder may not be
-!  "normal" after level 1 calculation)
+!  'normal' after level 1 calculation)
       i8_arr_lsum_level(:) = 0_i8
 
 !$omp parallel do      &
@@ -1129,7 +1129,7 @@ module shr_reprosum_mod
 ! sums over threads and MPI tasks: if value larger than or equal to
 ! (radix(IX_8)**arr_max_shift), add this 'overlap' to next larger integer in
 ! vector, resulting in nonoverlapping ranges for each component. Note that
-! "ilevel-1==0" corresponds to an extra level used to guarantee that the sums
+! 'ilevel-1==0' corresponds to an extra level used to guarantee that the sums
 ! over threads and MPI tasks do not overflow for ilevel==1.
           do ilevel=max_levels(ifld),1,-1
              RX_8 = i8_arr_tlsum_level(ilevel,ifld,ithread)
@@ -1194,7 +1194,7 @@ module shr_reprosum_mod
 
 ! Construct global sum from integer vector representation:
 !  1) arr_max_shift is the shift applied to fraction(arr_gmax) .
-!   When shifting back, need to "add back in" true arr_gmax exponent. This was
+!   When shifting back, need to 'add back in' true arr_gmax exponent. This was
 !   removed implicitly by working only with the fraction .
 !  2) want to add levels into sum in reverse order (smallest to largest). However,
 !   even this can generate floating point rounding errors if signs of integers
@@ -1227,7 +1227,7 @@ module shr_reprosum_mod
 ! preprocess integer vector:
 !  a) if value larger than or equal to (radix(IX_8)**arr_max_shift), add this 'overlap'
 !     to next larger integer in vector, resulting in nonoverlapping ranges for each
-!     component. Note that have "ilevel-1=0" level here as described above.
+!     component. Note that have 'ilevel-1=0' level here as described above.
            do ilevel=max_levels(ifld),1,-1
              RX_8 = i8_arr_gsum_level(ioffset+ilevel)
              IX_8 = int(scale(RX_8,-arr_max_shift),i8)
@@ -1411,7 +1411,7 @@ module shr_reprosum_mod
          llogunit = s_logunit
       endif
 
-      ! check that "fast" reproducible sum is accurate enough.
+      ! check that 'fast' reproducible sum is accurate enough.
       exceeds_limit = 0
       max_rel_diff = 0.0_r8
       max_abs_diff = 0.0_r8
@@ -1458,7 +1458,7 @@ module shr_reprosum_mod
 !----------------------------------------------------------------------
 !
 ! Purpose:
-! Compute the global sum of each field in "arr" using the indicated
+! Compute the global sum of each field in 'arr' using the indicated
 ! communicator with a reproducible yet scalable implementation based
 ! on He and Ding's implementation of the double-double algorithm.
 !

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -225,40 +225,169 @@ module shr_reprosum_mod
 ! representation. An alternative is to use an 'almost always
 ! reproducible' floating point algorithm (DDPDD), as described below.
 !
+! Description of integer vector algorithm:
+!-----------------------------------------
+! The basic idea is to represent the mantissa of each floating point
+! value as an integer, add these integers, and then convert back to a
+! floating point value. For a real*8 value, there are enough digits in
+! an integer*8 variable to not lose any information (in the
+! mantissa). However, each of these integers would have a different
+! implicit exponent if done in a naive way, and so the sum would not
+! be accurate. Also, even with the same 'normalization', the sum might
+! exceed the maximum value representable by an integer*8, causing
+! an overflow. Instead, a vector of integers is generated, where a
+! given element (or level using the terminology used in the code) of
+! the vector is associated with a particular exponent. The mantissa
+! for a given floating point value is then converted to some number of
+! integer values, depending on the exponent of the floating point
+! value, the normalization of its mantissa, the maximum number of
+! summands, the number of participating MPI tasks and of OpenMP
+! threads, and the exponents associated with the levels of the integer
+! vector, and added into the appropriate levels of the integer
+! vector. Each MPI task has its own integer vector representing the
+! local sum. This is then summed across all participating MPI tasks
+! using an MPI_Allreduce, and, lastly, converted back to a floating
+! point value. Note that the same approach works for a vector of
+! integer*4 variables, simply requiring more levels, both for the full
+! summation vector and for each individual real*8 summand. This is a
+! compile time option in the code, in support of systems for which the
+! compiler or MPI library has issues when using integer*8. As
+! implemented, this algorithm should work for any floating point and
+! integer type as long as they share the same base. The code is
+! written as if for real*8 and integer*8 variables, but the only
+! dependence is on the types 'r8' and 'i8', which are defined in the
+! code, currently with reference to the corresponding types in
+! shr_kind_mod. This is how integer*4 support is implemented, by
+! defining i8 to be shr_kind_i4 instead of shr_kind_i8.
+!
+! For this to work, each MPI task must have the same number of levels
+! and same implicit exponent for each level. These levels must be
+! sufficient to represent the smallest and largest nonzero individual
+! summands (in absolute value) and the largest possible intermediate
+! sum, including the final sum. Most of the complexity in the
+! algorithm is in identifying the number of levels, the exponent
+! associated with each level, and the appropriate levels to target
+! when converting a floating point value into its integer vector
+! representation. There are also some subtleties in reconstructing the
+! final sum from the integer vector, as described below. For each
+! floating point value, the exponent and mantissa are extracted using
+! the fortran intrinsics 'exponent' and 'fraction'. The mantissa is
+! then 'shifted' to match the exponent for a target level in the
+! integer vector using the 'scale' intrinsic. 'int(X,i8)' is used
+! for the conversion for the given level, and subtraction between
+! this integer and the original 'shifted' value identifies the
+! remainder that will be converted to an integer for the next level
+! in the vector. The logic continues until the remainder is zero. As
+! mentioned above, the only requirement, due to the implementation
+! using these fortran intrinsics, is that floating point and integer
+! models use the same base, e.g.  
+!  radix(1.0_r8) == radix(1_i8)
+! for real*8 and integer*8. If not, then the alternative algorithm
+! mentioned above and described below is used instead. The integer
+! representation must also have enough digits for the potential growth
+! of the sum for each level, so could conceivably be too small for a
+! large number of summands. 
+!
+! Upper bounds on the total number of summands and on all intermediate
+! sums are calculated as
+!  <number of MPI tasks>*<max number of summands per MPI task>
+! and
+!  <number of MPI tasks>*<max number of summands per MPI task>
+!   *<max absolute value over all nonzero summands>
+! respectively. The maximum number of summands per MPI task and the
+! maximum absolute value over all nonzero summands are global
+! information that need to be determined with additional MPI
+! collectives. The minimum nonzero absolute value summand is also
+! global information. Fortunately, all of these can be determined with
+! a single MPI_Allreduce call, so only one more than that required for
+! the sum itself. (Note that, in actuality, the exponents of max and
+! min summands are determined, and these are used to calculate bounds
+! on the maximum and minimum, allowing the use of an MPI_INTEGER
+! vector in the MPI_Allreduce call.)
+!
+! The actual code is made a little messier by (a) supporting summation
+! of multiple fields without increasing the number of MPI_Allreduce
+! calls, (b) supporting OpenMP threading of the local arithmetic, (c)
+! allowing the user to specify estimates for the global information
+! (to avoid the additional MPI_Allreduce), (d) including a check of
+! whether user specified bounds were sufficient and, if not,
+! determining the actual bounds and recomputing the sum, and (e)
+! allowing the user to specify the maximum number of levels to use,
+! potentially losing accuracy but still preserving reproducibility and
+! being somewhat cheaper to compute.
+!
+! The conversion of the local summands to vectors of integers, the
+! summation of the local vectors of integers, and the summation of the
+! distributed vectors of integers will be exact (if optional parameters
+! are not used to decrease the accuracy - see below). However, the
+! conversion of the vector of integer representation to a floating
+! point value may be subject to rounding errors. Before the
+! conversion, the vector of integers is adjusted so that all elements
+! have the same sign, eliminating the possibility of catastrophic
+! cancellation. These are integer operations, so no accuracy is
+! lost. Next, each element of the vector of integers is converted to a
+! floating point value and added into the intermediate sum, in
+! smallest to largest order (in absolute value). Any rounding error is
+! in the least significant digit for each intermediate sum, and the
+! exponents for each summand are monotonically increasing, so the
+! rounding errors do not accumulate. Thus, the relative difference
+! between the 'exact' value and that calculated by this algorithm will
+! be approximately machine epsilon for 64-bit real values, and any
+! difference will be restricted to the 16th significant digit in a
+! decimal representation. This does mean that the values calculated
+! with the integer*8 internal representation could differ from those
+! calculated using the integer*4 internal representation, but the
+! differences will be in the least significant digits. Similarly, the
+! results may change (in the least significant digits) with a change
+! in system, compiler, or compiler flags. However, for a fixed
+! internal representation, processor architecture, compiler, and
+! compiler options, the result will (still) be reproducible with
+! respect to MPI task and OpenMP thread counts.
+!
+! Description of optional parameters for integer vector algorithm:
+!-----------------------------------------------------------------
 ! The accuracy of the integer vector algorithm is controlled by the
-! number of 'levels' of integer expansion. The algorithm will calculate
-! the number of levels that is required for the sum to be essentially
-! exact. (The sum as represented by the integer expansion will be exact,
-! but roundoff may perturb the least significant digit of the returned
-! real*8 representation of the sum.) The optional parameter arr_max_levels
-! can be used to override the calculated value. The optional parameter
-! arr_max_levels_out can be used to return the values used.
+! total number of levels of integer expansion. The algorithm
+! calculates the number of levels that is required for the sum to be
+! essentially exact. (The sum as represented by the integer expansion
+! is exact, but roundoff may perturb the least significant digit of
+! the returned floating point representation of the sum.) The optional
+! parameter arr_max_levels can be used to override the calculated
+! value for each field. The optional parameter arr_max_levels_out can
+! be used to return the values used.
 !
-! The algorithm also requires an upper bound on
-! the maximum summand (in absolute value) for each field, and will
-! calculate this internally. However, if the optional parameters
+! The algorithm requires an upper bound on the maximum summand
+! (in absolute value) for each field, and will calculate this internally
+! using an MPI_Allreduce. However, if the optional parameters
 ! arr_max_levels and arr_gbl_max are both set, then the algorithm will
-! use the values in arr_gbl_max for the upper bounds instead. If these
-! are not upper bounds, or if the upper bounds are not tight enough
-! to achieve the requisite accuracy, and if the optional parameter
-! repro_sum_validate is NOT set to .false., the algorithm will repeat the
-! computation with appropriate upper bounds. If only arr_gbl_max is present,
-! then the maxima are computed internally (and the specified values are
-! ignored). The optional parameter arr_gbl_max_out can be
-! used to return the values used.
+! use the values in arr_gbl_max for the upper bounds instead. If only
+! arr_gbl_max is present, then the maxima are computed internally
+! (and the specified values are ignored). The optional parameter
+! arr_gbl_max_out can be used to return the values used.
 !
-! Finally, the algorithm requires an upper bound on the number of
-! local summands across all MPI tasks. This will be calculated internally,
-! using an MPI collective, but the value in the optional argument
-! gbl_max_nsummands will be used instead if (1) it is present, (2)
-! it is > 0, and (3) the maximum value and required number of levels
-! are also specified. (If the maximum value is calculated, the same
-! MPI collective is used to determine the maximum number of local
-! summands.) The accuracy of the user-specified value is not checked.
-! However, if set to < 1, the value will instead be calculated. If the
-! optional parameter gbl_max_nsummands_out is present, then the value
-! used (gbl_max_nsummands if >= 1; calculated otherwise) will be
-! returned.
+! The algorithm also requires an upper bound on the number of
+! local summands across all MPI tasks. (By definition, the number of
+! local summands is the same for each field on a given MPI task, i.e.,
+! the input parameter nsummands.) This will be calculated internally,
+! using an MPI_Allreduce, but the value in the optional argument
+! gbl_max_nsummands will be used instead if (1) it is present,
+! (2) the value is > 0, and (3) the maximum values and required number
+! of levels are also specified. (If the maximum values are calculated,
+! then the same MPI_Allreduce is used to determine the maximum numbers
+! of local summands.) The accuracy of the user-specified value is not
+! checked. However, if set to < 1, the value will instead be calculated.
+! If the optional parameter gbl_max_nsummands_out is present,
+! then the value used (gbl_max_nsummands if >= 1; calculated otherwise)
+! will be returned.
+!
+! If the user-specified upper bounds on maximum summands are
+! inaccurate or if the user-specified upper bounds (maximum summands
+! and number of local summands) and numbers of levels causes
+! any of the global sums to have fewer than the expected
+! number of significant digits, and if the optional parameter
+! repro_sum_validate is NOT set to .false., then the algorithm will
+! repeat the computations with internally calculated values for
+! arr_max_levels, arr_gbl_max, and gbl_max_nsummands.
 !
 ! If requested (by setting shr_reprosum_reldiffmax >= 0.0 and passing in
 ! the optional rel_diff parameter), results are compared with a
@@ -266,30 +395,38 @@ module shr_reprosum_mod
 !
 ! Note that the cost of the algorithm is not strongly correlated with
 ! the number of levels, which primarily shows up as a (modest) increase
-! in cost of the MPI_Allreduce as a function of vector length. Rather the
-! cost is more a function of (a) the number of integers required to
-! represent an individual summand and (b) the number of MPI_Allreduce
-! calls. The number of integers required to represent an individual
-! summand is 1 or 2 when using 8-byte integers for 8-byte real summands
-! when the number of local summands is not too large. As the number of
-! local summands increases, the number of integers required increases.
-! The number of MPI_Allreduce calls is either 2 (specifying nothing) or
-! 1 (specifying gbl_max_nsummands, arr_max_levels, and arr_gbl_max
-! correctly). When specifying arr_max_levels and arr_gbl_max
+! in the cost of the MPI_Allreduce as a function of vector length.
+! Rather the cost is more a function of (a) the number of integers
+! required to represent an individual summand and (b) the number of
+! MPI_Allreduce calls. The number of integers required to represent an
+! individual summand is 1 or 2 when using 8-byte integers for 8-byte
+! real summands when the number of local summands and number of MPI
+! tasks are not too large. As the magnitude of either of these increase,
+! the number of integers required increases. The number of
+! MPI_Allreduce calls is either 2 (specifying nothing or just
+! arr_max_levels and arr_gbl_max correctly) or 1 (specifying
+! gbl_max_nsummands, arr_max_levels, and arr_gbl_max correctly).
+! When specifying arr_max_nsummands, arr_max_levels, or arr_gbl_max
 ! incorrectly, 3 or 4 MPI_Allreduce calls will be required.
 !
+! Description of alternative (DDPDD) algorithm:
+!----------------------------------------------
 ! The alternative algorithm is a minor modification of a parallel
 ! implementation of David Bailey's routine DDPDD by Helen He
-! and Chris Ding. Bailey uses the Knuth trick to implement quadruple
-! precision summation of double precision values with 10 double
-! precision operations. The advantage of this algorithm is that
+! and Chris Ding. See, for example,
+!  Y. He, and C. Ding, 'Using Accurate Arithmetics to Improve
+!  Numerical Reproducibility and Stability in Parallel Applications,'
+!  J. Supercomputing, vol. 18, no. 3, 2001, pp. 259–277
+! and the citations therein. Bailey uses the Knuth trick to implement
+! quadruple precision summation of double precision values with 10
+! double precision operations. The advantage of this algorithm is that
 ! it requires a single MPI_Allreduce and is less expensive per summand
 ! than is the integer vector algorithm. The disadvantage is that it
 ! is not guaranteed to be reproducible (though it is reproducible
-! much more often than is the standard algorithm). This alternative
-! is used when the optional parameter ddpdd_sum is set to .true. It is
-! also used if the integer vector algorithm radix assumption does not
-! hold.
+! much more often than is the standard floating point algorithm).
+! This alternative is used when the optional parameter ddpdd_sum is
+! set to .true. It is also used if the integer vector algorithm radix
+! assumption does not hold.
 !
 !----------------------------------------------------------------------
 !
@@ -766,10 +903,20 @@ module shr_reprosum_mod
                                   'large for integer vector algorithm' )
             endif
 
-! determine maximum number of levels required for each field
-! ((digits(0.0_r8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) / arr_max_shift)
-! + 1 because first truncation probably does not involve a maximal shift
-! + 1 to guarantee that the integer division rounds up (not down)
+! Determine maximum number of levels required for each field.
+! Need enough levels to represent both the smallest and largest
+! nonzero summands (in absolute value), and any values in between.
+! The number of digits from the most significant digit in the
+! largest summand to the most significant digit in the smallest
+! summand is (arr_gmax_exp(ifld)-arr_gmin_exp(ifld)), and the maximum
+! number of digits needed to represent the smallest value is
+! digits(1.0_r8). Divide this total number of digits by the number of
+! digits per level (arr_max_shift) to get the number of levels
+!  ((digits(1.0_r8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) / arr_max_shift)
+! with some tweaks:
+!  + 1 because first truncation for any given summand probably does
+!  not involve a maximal shift (but this adds only one to the total)
+!  + 1 to guarantee that the integer division rounds up (not down)
 ! (setting lower bound on max_level*nflds to be 64 to improve OpenMP
 !  performance for loopb in shr_reprosum_int)
             max_level = (64/nflds) + 1
@@ -887,7 +1034,6 @@ module shr_reprosum_mod
          repro_sum_stats(6) = repro_sum_stats(6) + gbl_lor_red
       endif
 
-
    end subroutine shr_reprosum_calc
 
 !
@@ -969,7 +1115,8 @@ module shr_reprosum_mod
                                    !  jlevels of X_8 ('part' of
                                    !  i8_arr_gsum_level)
       integer(i8) :: i8_sign       ! sign global sum
-      integer(i8) :: i8_radix      ! radix for i8 variables
+      integer(i8) :: i8_radix      ! radix for i8 variables (and r8
+                                   !  variables by earlier if-test)
 
       integer :: max_error(nflds,omp_nthreads)
                                    ! accurate upper bound on data?
@@ -1357,7 +1504,6 @@ module shr_reprosum_mod
          endif
 
       enddo
-
 
    end subroutine shr_reprosum_int
 

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -122,7 +122,7 @@ module shr_reprosum_mod
       ! recompute using different algorithm when difference between
       ! reproducible and nonreproducible sums is too great
       logical, intent(in), optional  :: repro_sum_recompute_in
-      ! flag indicating whether this process should output
+      ! flag indicating whether this MPI task should output
       ! log messages
       logical, intent(in), optional  :: repro_sum_master
       ! unit number for log messages
@@ -248,7 +248,7 @@ module shr_reprosum_mod
 ! used to return the values used.
 !
 ! Finally, the algorithm requires an upper bound on the number of
-! local summands across all processes. This will be calculated internally,
+! local summands across all MPI tasks. This will be calculated internally,
 ! using an MPI collective, but the value in the optional argument
 ! gbl_max_nsummands will be used instead if (1) it is present, (2)
 ! it is > 0, and (3) the maximum value and required number of levels
@@ -329,11 +329,11 @@ module shr_reprosum_mod
 
       integer,  intent(in),    optional :: gbl_max_nsummands
                                          ! maximum of nsummand over all
-                                         ! processes
+                                         ! MPI tasks
 
       integer,  intent(out),   optional :: gbl_max_nsummands_out
                                          ! calculated maximum nsummands
-                                         ! over all processes
+                                         ! over all MPI tasks
 
       integer,  intent(in),    optional :: gbl_count
                                          ! was total number of summands;
@@ -396,11 +396,11 @@ module shr_reprosum_mod
                                          !  input array
       integer :: omp_nthreads            ! number of OpenMP threads
       integer :: mpi_comm                ! MPI subcommunicator
-      integer :: mypid                   ! MPI process ID (COMM_WORLD)
-      integer :: tasks                   ! number of MPI processes
+      integer :: mypid                   ! MPI task ID (COMM_WORLD)
+      integer :: tasks                   ! number of MPI tasks
       integer :: ierr                    ! MPI error return
       integer :: ifld, isum, ithread     ! loop variables
-      integer :: max_nsummands           ! max nsummands over all processes
+      integer :: max_nsummands           ! max nsummands over all MPI tasks
                                          !  or threads (used in both ways)
 
       integer, allocatable :: isum_beg(:), isum_end(:)
@@ -485,7 +485,7 @@ module shr_reprosum_mod
                call mpi_comm_rank(MPI_COMM_WORLD, mypid, ierr)
                write(s_logunit,37) real(nan_count,r8), real(inf_count,r8), mypid
 37 format("SHR_REPROSUM_CALC: Input contains ",e12.5, &
-          " NaNs and ", e12.5, " INFs on process ", i7)
+          " NaNs and ", e12.5, " INFs on MPI task ", i7)
                call shr_sys_abort("shr_reprosum_calc ERROR: NaNs or INFs in input")
             endif
 
@@ -1126,11 +1126,11 @@ module shr_reprosum_mod
           enddo
 
 ! postprocess integer vector to eliminate potential for overlap in the following
-! sums over threads and processes: if value larger than or equal to
+! sums over threads and MPI tasks: if value larger than or equal to
 ! (radix(IX_8)**arr_max_shift), add this 'overlap' to next larger integer in
 ! vector, resulting in nonoverlapping ranges for each component. Note that
 ! "ilevel-1==0" corresponds to an extra level used to guarantee that the sums
-! over threads and processes do not overflow for ilevel==1.
+! over threads and MPI tasks do not overflow for ilevel==1.
           do ilevel=max_levels(ifld),1,-1
              RX_8 = i8_arr_tlsum_level(ilevel,ifld,ithread)
              IX_8 = int(scale(RX_8,-arr_max_shift),i8)
@@ -1215,7 +1215,7 @@ module shr_reprosum_mod
          ioffset = offset(ifld)
 
 ! if validate is .true., test whether the summand upper bound
-!  was exceeded on any of the processes
+!  was exceeded on any of the MPI tasks
          if (validate) then
             if (i8_arr_gsum_level(ioffset-voffset+1) .ne. 0_i8) then
                recompute = .true.
@@ -1379,7 +1379,7 @@ module shr_reprosum_mod
 !
       character(len=*), intent(in) :: name    ! distributed sum identifier
       integer,  intent(in) :: nflds           ! number of fields
-      logical,  intent(in) :: master          ! process that will write
+      logical,  intent(in) :: master          ! MPI task that will write
                                               !  warning messages?
       integer, optional, intent(in) :: logunit! unit warning messages
                                               !  written to

--- a/src/shr_reprosum_mod.F90
+++ b/src/shr_reprosum_mod.F90
@@ -283,10 +283,10 @@ module shr_reprosum_mod
 ! models use the same base, e.g.  
 !  radix(1.0_r8) == radix(1_i8)
 ! for real*8 and integer*8. If not, then the alternative algorithm
-! mentioned above and described below is used instead. The integer
-! representation must also have enough digits for the potential growth
-! of the sum for each level, so could conceivably be too small for a
-! large number of summands. 
+! DDPDD mentioned above and described below is used instead. The
+! integer representation must also have enough digits for the
+! potential growth of the sum for each level, so could conceivably be
+! too small for a large number of summands. 
 !
 ! Upper bounds on the total number of summands and on all intermediate
 ! sums are calculated as
@@ -323,26 +323,38 @@ module shr_reprosum_mod
 ! conversion of the vector of integer representation to a floating
 ! point value may be subject to rounding errors. Before the
 ! conversion, the vector of integers is adjusted so that all elements
-! have the same sign, eliminating the possibility of catastrophic
-! cancellation. These are integer operations, so no accuracy is
-! lost. Next, each element of the vector of integers is converted to a
-! floating point value and added into the intermediate sum, in
-! smallest to largest order (in absolute value). Any rounding error is
-! in the least significant digit for each intermediate sum, and the
-! exponents for each summand are monotonically increasing, so the
-! rounding errors do not accumulate. Thus, the relative difference
-! between the 'exact' value and that calculated by this algorithm will
-! be approximately machine epsilon for 64-bit real values, and any
-! difference will be restricted to the 16th significant digit in a
-! decimal representation. This does mean that the values calculated
-! with the integer*8 internal representation could differ from those
-! calculated using the integer*4 internal representation, but the
-! differences will be in the least significant digits. Similarly, the
-! results may change (in the least significant digits) with a change
-! in system, compiler, or compiler flags. However, for a fixed
-! internal representation, processor architecture, compiler, and
-! compiler options, the result will (still) be reproducible with
-! respect to MPI task and OpenMP thread counts.
+! have the same sign, and so that the value, in absolute value, at a
+! given level is strictly less than what can be represented at the
+! next lower level (larger exponent) and strictly greater than what
+! can represented at the next higher level (smaller exponent). Since
+! all elements have the same sign, the sign is set to positive
+! temporarily and then restored when the conversion to floating point
+! is complete. These are all integer operations, so no accuracy is
+! lost. These adjustments eliminate the possibility of catastrophic
+! cancellation. Also, when converting the individual elements to
+! floating point values and summing them, the summation is now
+! equivalent to concatenating the digits in the mantissas for the
+! component summands. In consequence, in the final step when each
+! element of this modified vector of integers is converted to a
+! floating point value and added into the intermediate sum, any
+! rounding is limited to the least significant digit representable
+! in the final floating point sum.
+!
+! Any such rounding error will be sensitive to the particular floating
+! values generated from the integer vector, and so will be 
+! sensitive to the number of levels in the vector and the implicit
+! exponent associated with each level, which are themselves functions
+! of the numbers of MPI tasks and OpenMP threads and the number of
+! digits representable in an integer. To avoid this sensitivity,
+! (effectively) generate a new integer vector in which each component
+! integer has a fixed number of significant digits (e.g.,
+! digits(1.0_r8)) and generate the floating point values from these
+! before summing. (See comments in code for more details.) This
+! creates a sequence of floating point values to be summed that are
+! independent of, for example, the numbers of MPI tasks and OpenMP
+! threads or whether using integer*8 or integer*4 internal
+! representations in the integer vector, and thus ensure
+! reproducibility with respect to these options.
 !
 ! Description of optional parameters for integer vector algorithm:
 !-----------------------------------------------------------------
@@ -1146,9 +1158,6 @@ module shr_reprosum_mod
 !
 ! Local workspace
 !
-      integer, parameter  :: max_jlevel = &
-                                1 + (digits(1_i8)/digits(1.0_r8))
-
       integer(i8) :: i8_arr_tlsum_level(-(extra_levels-1):max_level,nflds,omp_nthreads)
                                    ! integer vector representing local
                                    !  sum (per thread, per field)
@@ -1160,9 +1169,10 @@ module shr_reprosum_mod
       integer(i8) :: i8_arr_gsum_level((max_level+extra_levels+2)*nflds)
                                    ! integer vector representing global
                                    !  sum
-      integer(i8) :: IX_8          ! integer representation of current
-                                   !  jlevels of X_8 ('part' of
-                                   !  i8_arr_gsum_level)
+      integer(i8) :: i8_gsum_level(-(extra_levels-1):max_level)
+                                   ! integer vector representing global
+                                   !  sum for one field
+      integer(i8) :: IX_8          ! integer representation of r8 value
       integer(i8) :: i8_sign       ! sign global sum
       integer(i8) :: i8_radix      ! radix for i8 variables (and r8
                                    !  variables by earlier if-test)
@@ -1175,7 +1185,7 @@ module shr_reprosum_mod
       integer :: isum_beg(omp_nthreads), isum_end(omp_nthreads)
                                    ! range of summand indices for each
                                    !  OpenMP thread
-      integer :: ifld, isum, ithread
+      integer :: ifld, isum, ithread, jlevel
                                    ! loop variables
       integer :: arr_exp           ! exponent of summand
       integer :: arr_shift         ! exponent used to generate integer
@@ -1189,13 +1199,28 @@ module shr_reprosum_mod
       integer :: min_level         ! index of minimum levels (including
                                    !  extra levels) for i8_arr_tlsum_level
       integer :: ioffset           ! offset(ifld)
-      integer :: jlevel            ! number of floating point 'pieces'
-                                   !  extracted from a given i8 integer
+      integer :: svlevel           ! number of summands in summand_vector
       integer :: ierr              ! MPI error return
-      integer :: LX(max_jlevel)    ! exponent of X_8 (see below)
+      integer :: LX                ! exponent of X_8 (see below)
       integer :: veclth            ! total length of i8_arr_lsum_level
-      integer :: sum_digits        ! lower bound on number of significant
-                                   !  in integer expansion of sum
+      integer :: i8_digit_count    ! number of digits in integer
+                                   !  expansion of sum
+      integer :: i8_begin_level    ! level starting from in
+                                   !  creating next 'exactly representable'
+                                   !  floating point value from modified
+                                   !  integer expansion of the sum
+      integer :: i8_trunc_level    ! level at which the number of digits in
+                                   !  the modified integer expansion of the
+                                   !  sum exceeds the number of representable
+                                   !  digits in the floating point sum
+      integer :: i8_trunc_loc      ! location of last digit at i8_trunc_level
+                                   !  in the modified integer expansion of the
+                                   !  sum that is representable in the floating
+                                   !  point sum
+      integer(i8) :: i8_trunc_level_rem
+                                   ! truncated digits at i8_trunc_level
+                                   !  in the modified integer expansion
+                                   !  of the sum
       integer :: curr_exp          ! exponent of partial sum during
                                    !  reconstruction from integer vector
       integer :: corr_exp          ! exponent of current summand in
@@ -1204,18 +1229,21 @@ module shr_reprosum_mod
       real(r8) :: arr_frac         ! fraction of summand
       real(r8) :: arr_remainder    ! part of summand remaining after
                                    !  current level of integer expansion
-      real(r8) :: X_8(max_jlevel)  ! r8 vector representation of current
+      real(r8) :: X_8              ! r8 representation of current
                                    !  i8_arr_gsum_level
-      real(r8) :: RX_8             ! r8 representation of difference
-                                   !  between current i8_arr_gsum_level
-                                   !  and current jlevels of X_8
-                                   !  (== IX_8). Also used in final
-                                   !  scaling step
+      real(r8) :: RX_8             ! r8 representation of (other)
+                                   !  integers used in calculation.
+      real(r8) :: summand_vector(max_level)
+                                   ! vector of r8 values generated from
+                                   !  integer vector representation to be
+                                   !  summed to generate global sum
 
-      logical :: first             ! flag used to indicate that just
-                                   !  beginning reconstruction of sum
-                                   !  from integer vector
-
+      logical :: first_stepd_iteration
+                                   ! flag used to indicate whether first
+                                   !  time through process of converting
+                                   !  vector of integers into a floating
+                                   !  point value, as it requires
+                                   !  special logic
 !
 !------------------------------------------------------------------------
 ! Save radix of i8 variables in an i8 variable
@@ -1325,7 +1353,6 @@ module shr_reprosum_mod
             endif
 
           enddo
-
 ! Postprocess integer vector to eliminate possibility of overflow
 ! during subsequent sum over threads and tasks, as per earlier
 ! comment on logic behind definition of max_nsummands. If value at a
@@ -1448,27 +1475,79 @@ module shr_reprosum_mod
 #endif
 #endif
 
+      call t_startf('repro_sum_finalsum')
 ! Construct global sum from integer vector representation:
 !  1) arr_max_shift is the shift applied to fraction(arr_gmax) .
-!   When shifting back, need to 'add back in' true arr_gmax exponent. This was
-!   removed implicitly by working only with the fraction .
-!  2) Want to add levels into sum in reverse order (smallest to largest). However,
-!   even this can generate floating point rounding errors if signs of integers
-!   alternate. To avoid this, do some arithmetic with integer vectors so that all
-!   components have the same sign. This should keep relative difference between
-!   using different integer sizes (e.g. i8 and i4) to machine epsilon
-!  3) Assignment to X_8 will usually lose accuracy since maximum integer
-!   size is greater than the max number of 'digits' in r8 value (if xmax_nsummands
-!   correction not very large). Calculate remainder and add in first (since
-!   smaller). One correction is sufficient for r8 (53 digits) and i8 (63 digits).
-!   For r4 (24 digits) may need to correct twice. Code is written in a general
-!   fashion, to work no matter how many corrections are necessary (assuming
-!   max_jlevel parameter calculation is correct).
+!   When shifting back, need to 'add back in' the true arr_gmax exponent.
+!   This was removed implicitly by working only with the fraction.
+!  2) To avoid the possibility of catastrophic cancellation, and
+!   an unacceptable floating point rounding error, can do some arithmetic
+!   with the integer vector so that all components have the same sign.
+!  3) If convert each integer in the integer vector to a floating
+!   point value and then add these together, smallest to largest, to
+!   calculate the final sum, there may be roundoff error in the least
+!   significant digit. This error will be sensitive to the particular
+!   floating values generated from the integer vector, and so will be
+!   sensitive to the number of levels in the vector and the implicit
+!   exponent associated with each level. So this approach is not
+!   guaranteed to be reproducible with respect to a change in the
+!   number of MPI tasks and OpenMP threads (as this changes the
+!   definition of max_nsummands, and thus also arr_max_shift). It is
+!   also not guaranteed to be reproducible with respect to changing
+!   the integer size, e.g. from i8 to i4, as this also changes
+!   arr_max_shift. However, can eliminate this potential loss of
+!   reproducibility by taking the following steps. 
+!   a) Manipulate the integer vector so that
+!    i)  the component values do not 'overlap', that is, the value
+!        represented by a component is strictly less than the value
+!        represented by the least significant digit in the previous
+!        component, and 
+!    ii) all components are positive (saving the sign to be restored
+!        to the final result).
+!   b) Identify the digit in the resulting integer vector that is the
+!      last representable in the floating point representation, then
+!      truncate the vector at this point, i.e., all digits of lesser
+!      significance in the given component and all components
+!      representing digits of lesser significance (call this the
+!      remainder). 
+!   c) Convert each integer component in the modified integer vector
+!      to its corresponding floating point value and sum the
+!      sequence. (Order is unimportant, as explained below, but here
+!      add largest to smallest.) 
+!   d) Repeat (b) and (c) for the remainder (recursively, as
+!      necessary).
+!   e) Sum all floating point numbers generated by step (c), smallest
+!      to largest. 
+!   f) Restore the sign.
+!   With the manipulations in (a) and (b), the summation in (c) is
+!   equivalent to concatenating the digits in the mantissas for the
+!   component summands, so rounding is irrelevant (so far). Repeating
+!   this with the remainder(s) generates a sequence of 'exact'
+!   floating point numbers. Summing these can still generate a
+!   rounding error in the least significant digit in the largest
+!   floating point value (which is the last representable digit in the
+!   final result), but the floating point values being summed and
+!   order of summation are independent of the number of levels and
+!   implicit exponents, so reproducibility is ensured.
+!  
+!  Note that assignment of an i8 integer value to an r8 floating point
+!  variable in step (c) can lead to a loss of accuracy because the
+!  maximum number of digits in the i8 integer can be greater than the
+!  maximum number of digits representable in the r8 variable (if the
+!  xmax_nsummands correction is not very large). With the same sign
+!  and nonoverlapping properties of the integer components, these lost
+!  digits will also not be representable in the final sum. The process
+!  described above of truncating at this last representable digit, and
+!  then separately generating floating point value(s) for the
+!  remainder, takes care of this automatically. Similar reasoning
+!  applies to r4 floating point values with either i8 or i4 integer
+!  components.
 
       recompute = .false.
       do ifld=1,nflds
          arr_gsum(ifld) = 0.0_r8
          ioffset = offset(ifld)
+         svlevel = 0
 
 ! If validate is .true., test whether the summand upper bound
 ! was exceeded on any of the MPI tasks
@@ -1479,9 +1558,17 @@ module shr_reprosum_mod
          endif
 
          if (.not. recompute) then
+! Copy integer vector for current field from i8_arr_gsum_level, so that
+! can be modified without changing i8_arr_gsum_level. (Preserving
+! i8_arr_gsum_level unchanged is not necessary, but is convenient for debugging
+! and makes indexing clearer and less error prone.)
+            i8_gsum_level(:) = 0_i8
+            do ilevel=min_level,max_levels(ifld)
+               i8_gsum_level(ilevel) = i8_arr_gsum_level(ioffset+ilevel)
+            enddo
 
-! Preprocess integer vector:
-!  a) If value larger than or equal to (radix(1_i8)**arr_max_shift),
+! Preprocess integer vector (as described in 3(a) above):
+!  i) If value larger than or equal to (radix(1_i8)**arr_max_shift),
 !     add this 'overlap' to the value at the next smaller level
 !     in the vector, resulting in nonoverlapping ranges for each
 !     component.
@@ -1512,144 +1599,248 @@ module shr_reprosum_mod
 !     -(extra_levels-1), does not have to be less than
 !     (radix(1_i8)**arr_max_shift) for this 'nonoverlap' property to
 !     hold. 
-           do ilevel=max_levels(ifld),min_level+1,-1
-              if (abs(i8_arr_gsum_level(ioffset+ilevel)) >= &
-                     (i8_radix**arr_max_shift)) then
-
-                  IX_8 = i8_arr_gsum_level(ioffset+ilevel) &
+            do ilevel=max_levels(ifld),min_level+1,-1
+               if (abs(i8_gsum_level(ilevel)) >= &
+                      (i8_radix**arr_max_shift)) then
+                  
+                  IX_8 = i8_gsum_level(ilevel) &
                          / (i8_radix**arr_max_shift)
-                  i8_arr_gsum_level(ioffset+ilevel-1) = &
-                     i8_arr_gsum_level(ioffset+ilevel-1) + IX_8
-
+                  i8_gsum_level(ilevel-1) = &
+                     i8_gsum_level(ilevel-1) + IX_8
+                  
                   IX_8 = IX_8*(i8_radix**arr_max_shift)
-                  i8_arr_gsum_level(ioffset+ilevel)   = &
-                     i8_arr_gsum_level(ioffset+ilevel) - IX_8
-              endif
-           enddo
-!  b) Working consecutively from the first level with a nonzero value
-!     up to level max_levels(ifld), subtract +/- 1 from level with
-!     larger exponent (e.g., ilevel) and add  +/-
-!     (i8_radix**arr_max_shift) to level with smaller exponent
-!     (ilevel+1), when necessary, so that the value at ilevel+1
-!     has the same sign as the value at ilevel. Treat a zero value at
-!     ilevel+1 as always a different sign from the value at ilevel so
-!     that the process always makes this nonzero. (Otherwise, the
-!     wrong sign could be reintroduced by subtracting from a zero
-!     value at the next step.) When finished with the process values
-!     at all levels are either greater than or equal to zero or all
-!     are less than or equal to zero. Note that this can decrease (but
-!     not increase) the absolute value at level -(extra_levels-1) by
-!     1. All other levels are now less than or equal to
-!     (radix(1_i8)**arr_max_shift) in absolute value rather than
-!     strictly less than. 
-           ilevel = min_level
-           do while ((i8_arr_gsum_level(ioffset+ilevel) == 0_i8) &
-                     .and. (ilevel < max_levels(ifld)))
-             ilevel = ilevel + 1
-           enddo
-!
-           if (ilevel < max_levels(ifld)) then
-              if (i8_arr_gsum_level(ioffset+ilevel) > 0_i8) then
-                 i8_sign = 1_i8
-              else
-                 i8_sign = -1_i8
-              endif
-              do jlevel=ilevel,max_levels(ifld)-1
-                 if ((sign(1_i8,i8_arr_gsum_level(ioffset+jlevel)) &
-                      /= sign(1_i8,i8_arr_gsum_level(ioffset+jlevel+1))) &
-                     .or. (i8_arr_gsum_level(ioffset+jlevel+1) == 0_i8)) then
-                    i8_arr_gsum_level(ioffset+jlevel)   = &
-                       i8_arr_gsum_level(ioffset+jlevel) - i8_sign
-                    i8_arr_gsum_level(ioffset+jlevel+1) = &
-                       i8_arr_gsum_level(ioffset+jlevel+1) &
-                       + i8_sign*(i8_radix**arr_max_shift)
-                 endif
-              enddo
-            endif
-
-! Start with maximum shift, and work up to larger values
-            arr_shift = arr_gmax_exp(ifld) &
-                        - max_levels(ifld)*arr_max_shift
-            curr_exp = 0
-            first = .true.
-            do ilevel=max_levels(ifld),min_level,-1
-
-               if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
-                  jlevel = 1
-
-! r8 representation of higher order bits in integer
-                  X_8(jlevel) = i8_arr_gsum_level(ioffset+ilevel)
-                  LX(jlevel)  = exponent(X_8(jlevel))
-
-! Calculate remainder
-                  IX_8 = int(X_8(jlevel),i8)
-                  RX_8 = (i8_arr_gsum_level(ioffset+ilevel) - IX_8)
-
-! Repeat using remainder
-                  do while (RX_8 /= 0.0_r8)
-                     jlevel = jlevel + 1
-                     X_8(jlevel) = RX_8
-                     LX(jlevel) = exponent(RX_8)
-                     IX_8 = IX_8 + int(RX_8,i8)
-                     RX_8 = (i8_arr_gsum_level(ioffset+ilevel) - IX_8)
-                  enddo
-
-! Add in contributions, smaller to larger, rescaling for each
-! addition to guarantee that exponent of working summand is always
-! larger than minexponent
-                  do while (jlevel > 0)
-                     if (first) then
-                        curr_exp = LX(jlevel) + arr_shift
-                        arr_gsum(ifld) = fraction(X_8(jlevel))
-                        first = .false.
-                     else
-                        corr_exp = curr_exp - (LX(jlevel) + arr_shift)
-                        arr_gsum(ifld) = fraction(X_8(jlevel)) &
-                                       + scale(arr_gsum(ifld),corr_exp)
-                        curr_exp = LX(jlevel) + arr_shift
-                     endif
-                     jlevel = jlevel - 1
-                  enddo
-
+                  i8_gsum_level(ilevel)   = &
+                     i8_gsum_level(ilevel) - IX_8
                endif
-
-               arr_shift = arr_shift + arr_max_shift
             enddo
 
-! Apply final exponent correction, scaling first if exponent is too small
-! to apply directly
-            corr_exp = curr_exp + exponent(arr_gsum(ifld))
-            if (corr_exp >= MINEXPONENT(1.0_r8)) then
-               arr_gsum(ifld) = set_exponent(arr_gsum(ifld),corr_exp)
+!  ii) Working consecutively from the first level with a nonzero value
+!      up to level max_levels(ifld), subtract +/- 1 from level with
+!      larger exponent (e.g., ilevel) and add  +/-
+!      (i8_radix**arr_max_shift) to level with smaller exponent
+!      (ilevel+1), when necessary, so that the value at ilevel+1
+!      has the same sign as the value at ilevel. Treat a zero value at
+!      ilevel+1 as always a different sign from the value at ilevel so
+!      that the process always makes this nonzero. (Otherwise, the
+!      wrong sign could be reintroduced by subtracting from a zero
+!      value at the next step.) When finished with the process values
+!      at all levels are either greater than or equal to zero or all
+!      are less than or equal to zero. Note that this can decrease
+!      (but not increase) the absolute value at level
+!      -(extra_levels-1) by 1. All other levels are now less than or
+!      equal to (radix(1_i8)**arr_max_shift) in absolute value rather
+!      than strictly less than. 
+            ilevel = min_level
+            do while ((i8_gsum_level(ilevel) == 0_i8) &
+                      .and. (ilevel < max_levels(ifld)))
+               ilevel = ilevel + 1
+            enddo
+!
+            if (i8_gsum_level(ilevel) < 0_i8) then
+               i8_sign = -1_i8
             else
-               RX_8 = set_exponent(arr_gsum(ifld), &
-                                   corr_exp-MINEXPONENT(1.0_r8))
-               arr_gsum(ifld) = scale(RX_8,MINEXPONENT(1.0_r8))
+               i8_sign = 1_i8
+            endif
+!            
+            if (ilevel < max_levels(ifld)) then
+               do jlevel=ilevel,max_levels(ifld)-1
+                  if ((sign(1_i8,i8_gsum_level(jlevel)) &
+                       /= sign(1_i8,i8_gsum_level(jlevel+1)))&
+                      .or. (i8_gsum_level(jlevel+1) == 0_i8)) then
+                     i8_gsum_level(jlevel)   = &
+                       i8_gsum_level(jlevel) - i8_sign
+                     i8_gsum_level(jlevel+1) = &
+                        i8_gsum_level(jlevel+1) &
+                        + i8_sign*(i8_radix**arr_max_shift)
+                  endif
+               enddo
             endif
 
-! If validate is .true. and some precision lost, test whether 'too much'
-! was lost, due to too loose an upper bound, too stringent a limit on number
-! of levels of expansion, cancellation, .... Calculated by comparing lower
-! bound on number of sigificant digits with number of digits in 1.0_r8 .
+!  iii) If 'same sign' is negative, then change to positive
+!       temporarily. 
+            if (i8_sign < 0_i8) then
+               do jlevel=ilevel,max_levels(ifld)
+                  i8_gsum_level(jlevel) = -i8_gsum_level(jlevel)
+               enddo
+            endif
+
+!  iv) Nonoverlap property can be lost after imposition of same sign
+!      over components. Reintroduce this property (retaining same sign
+!      property). Note that carryover is never more than '1' to the
+!      next smaller level, so, again, no intermediate or final sums
+!      will exceed the maximum value representable in i8, including
+!      level -(extra_levels-1) as long as digits(1_i8) >= 4. 
+            do ilevel=max_levels(ifld),min_level+1,-1
+               if (abs(i8_gsum_level(ilevel)) >= &
+                      (i8_radix**arr_max_shift)) then
+                  
+                  IX_8 = i8_gsum_level(ilevel)/ &
+                         (i8_radix**arr_max_shift)
+                  i8_gsum_level(ilevel-1) = &
+                     i8_gsum_level(ilevel-1) + IX_8
+                  
+                  IX_8 = IX_8*(i8_radix**arr_max_shift)
+                  i8_gsum_level(ilevel)   = &
+                     i8_gsum_level(ilevel) - IX_8
+               endif
+            enddo
+
+! Step 3(d): iterate over steps 3(b) and 3(c), truncating integer
+! vector to 'fit' into a floating point value, then repeating with
+! remainder
+            first_stepd_iteration = .true.
+            arr_shift = arr_gmax_exp(ifld) - (min_level)*arr_max_shift
+            i8_digit_count = 0
+            i8_begin_level = min_level
+            do while (i8_begin_level <= max_levels(ifld))
+   
+! Determine at which level the total number of integer digits equals
+! or exceeds the number of digits representable in the floating point
+! sum. Then determine which digit at this level is the last
+! representable in the floating point sum. Note that this location
+! (i8_trunc_loc) is zero-based, i.e. smallest digit is at location
+! 0. Note that the exponent is a count of the number of digits for the
+! first nonzero level. All subsequent levels contribute arr_max_shift
+! digits.
+               i8_trunc_loc = 0
+               i8_trunc_level = max_levels(ifld)
+               do ilevel=i8_begin_level,max_levels(ifld)
+                  if (first_stepd_iteration) then
+! Special logic for first time through. Subsequent iterations treat
+! leading zeroes as significant.                  
+                     if (i8_digit_count == 0) then
+                        if (i8_gsum_level(ilevel) /= 0_i8) then
+                           X_8 = i8_gsum_level(ilevel)
+                           LX  = exponent(X_8)
+! Note that even if i8_gsum_level(ilevel) is truncated when assigned
+! to X_8, the exponent LX will still capture the original number of
+! digits.
+                        else
+                           LX = 0
+                        endif
+                     else
+                        LX = arr_max_shift
+                     endif
+                  else
+! If i8_digit_count /= 0 during the first iteration
+! (ilevel == i8_begin_level), then there is a remainder left at the
+! previous i8_trunc_level and LX should be set to zero for this
+! iteration.
+                     if ((ilevel == i8_begin_level) .and. (i8_digit_count /= 0)) then
+                        LX = 0
+                     else
+                        LX = arr_max_shift
+                     endif
+                  endif
+                  if (i8_digit_count + LX >= digits(1.0_r8)) then
+                     i8_trunc_level = ilevel
+                     i8_trunc_loc = (i8_digit_count + LX) - digits(1.0_r8)
+                     exit
+                  else
+                     i8_digit_count = i8_digit_count + LX
+                  endif
+               enddo
+               first_stepd_iteration = .false.
+
+! Truncate at i8_trunc_loc as needed and determine what the remainder
+! is. 
+               if (i8_trunc_loc == 0) then
+! No truncation is necessary, and remainder is just the components
+! for the remaining levels
+                  i8_trunc_level_rem = 0
+               else
+! Shift right to identify the digits to be preserved and truncate
+! there
+                  IX_8 = i8_gsum_level(i8_trunc_level)/ &
+                         (i8_radix**i8_trunc_loc)
+! Shift left to put digits in the correct location (right fill with
+! zeroes)
+                  IX_8 = IX_8*(i8_radix**i8_trunc_loc)
+! Calculate local remainder
+                  i8_trunc_level_rem = (i8_gsum_level(i8_trunc_level) - IX_8)
+! Update level with the truncated value
+                  i8_gsum_level(i8_trunc_level) = IX_8
+               endif
+                  
+! Calculate floating point value corresponding to modified integer
+! vector. Note that, by construction, i8 integer value will fit into
+! r8 floating point value, so do not need to test for this.
+               svlevel = svlevel + 1
+               summand_vector(svlevel) = 0.0_r8
+               do ilevel=i8_begin_level,i8_trunc_level
+                  if (i8_gsum_level(ilevel) /= 0_i8) then
+
+! Convert integer to floating point representation
+                     X_8 = i8_gsum_level(ilevel)
+                     LX  = exponent(X_8)
+
+! Add to vector of floating point summands, scaling first if exponent
+! is too small to apply directly
+                     curr_exp = LX + arr_shift
+                     if (curr_exp >= MINEXPONENT(1.0_r8)) then
+                        summand_vector(svlevel) = &
+                           summand_vector(svlevel) + set_exponent(X_8,curr_exp)
+                     else
+                        RX_8 = set_exponent(X_8, &
+                                            curr_exp-MINEXPONENT(1.0_r8))
+                        summand_vector(svlevel) = &
+                           summand_vector(svlevel) + scale(RX_8,MINEXPONENT(1.0_r8))
+                     endif
+                     
+                  endif
+
+! Note that same arr_shift should be used for next 'step 3(d)'
+! iteration if i8_trunc_loc > 0.
+                  if ((ilevel < i8_trunc_level) .or. (i8_trunc_loc == 0)) then
+                     arr_shift = arr_shift - arr_max_shift
+                  endif
+
+               enddo
+
+               if (i8_trunc_loc == 0) then
+                  i8_digit_count = 0
+                  i8_begin_level = i8_trunc_level + 1
+               else
+                  i8_digit_count = i8_trunc_loc
+                  i8_begin_level = i8_trunc_level
+                  i8_gsum_level(i8_trunc_level) = i8_trunc_level_rem
+               endif
+            
+            enddo
+
+! Step 3(e): sum vector of floating point values, smallest to largest
+            arr_gsum(ifld) = 0.0_r8
+            do jlevel=svlevel,1,-1
+               arr_gsum(ifld) = arr_gsum(ifld) + summand_vector(jlevel)
+            enddo
+
+! Step 3(f): restore the sign
+            arr_gsum(ifld) = i8_sign*arr_gsum(ifld)
+
+! If validate is .true. and some precision lost, test whether 'too
+! much' was lost, due to too loose an upper bound, too stringent a
+! limit on number of levels of expansion, cancellation, ...
+! Calculated by comparing lower bound on number of significant digits
+! with number of digits in 1.0_r8 .
             if (validate) then
                if (i8_arr_gsum_level(ioffset-voffset+2) /= 0_i8) then
 
-! Find first nonzero level and use exponent for this level, then assume all
-! subsequent levels contribute arr_max_shift digits.
-                  sum_digits = 0
+! Find first nonzero level and use exponent for this level, then
+! assume all subsequent levels contribute arr_max_shift digits.
+                  i8_digit_count = 0
                   do ilevel=min_level,max_levels(ifld)
-                     if (sum_digits == 0) then
+                     if (i8_digit_count == 0) then
                         if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
-                           X_8(1) = i8_arr_gsum_level(ioffset+ilevel)
-                           LX(1)  = exponent(X_8(1))
-                           sum_digits = LX(1)
+                           X_8 = i8_arr_gsum_level(ioffset+ilevel)
+                           LX  = exponent(X_8)
+                           i8_digit_count = LX
                         endif
                      else
-                        sum_digits = sum_digits + arr_max_shift
+                        i8_digit_count = i8_digit_count + arr_max_shift
                      endif
                   enddo
 
-                  if (sum_digits < digits(1.0_r8)) then
+                  if (i8_digit_count < digits(1.0_r8)) then
                      recompute = .true.
                   endif
                endif
@@ -1658,6 +1849,7 @@ module shr_reprosum_mod
          endif
 
       enddo
+      call t_stopf('repro_sum_finalsum')
 
    end subroutine shr_reprosum_int
 
@@ -1745,7 +1937,6 @@ module shr_reprosum_mod
          endif
          shr_reprosum_tolExceeded = .true.
        endif
-
 
    end function shr_reprosum_tolExceeded
 
@@ -1872,7 +2063,6 @@ module shr_reprosum_mod
 ! The result is t1 + t2, after normalization.
          ddb(i) = cmplx ( t1 + t2, t2 - ((t1 + t2) - t1), r8 )
       enddo
-
 
    end subroutine DDPDD
 !


### PR DESCRIPTION
## Summary

This PR brings in three related sets of fixes/cleanups to shr_reprosum_mod from @worleyph , which were made to E3SM about 3 years ago:
- https://github.com/E3SM-Project/E3SM/pull/5534
- https://github.com/E3SM-Project/E3SM/pull/5549
- https://github.com/E3SM-Project/E3SM/pull/5560

Resolves #79 

This **changes answers for CAM-FV cases**, and may change answers for other cases, but I haven't observed other answer changes from my so-far-limited testing.

## How I brought in these changes

I brought in the changes by cherry-picking the commits that were made in E3SM. I organized these into three batches so that I could make a merge commit corresponding to each of the E3SM PRs, where the merge commit message summarizes the changes in the corresponding batch.

I then compared the final shr_reprosum_mod.F90 with the version in E3SM. These are now identical except for the following:

(1) CESM has numerous `#ifdef TIMING`, whereas E3SM has `#ifndef EAMXX_STANDALONE`. There are also some whitespace differences between the CESM and E3SM versions around these ifdefs.

(2) CESM has `#include <mpif.h>`, E3SM has `use mpi`

(3) E3SM has:

```Fortran
#ifdef EAMXX_STANDALONE   
   ! Declare the C function interface
   interface
      subroutine shr_reprosumx86_fix_start(arg) bind(c)
        use iso_c_binding
        integer, intent(out) :: arg
      end subroutine shr_reprosumx86_fix_start
   end interface

   interface
      subroutine shr_reprosumx86_fix_end(arg) bind(c)
        use iso_c_binding
        integer, intent(in) :: arg
      end subroutine shr_reprosumx86_fix_end
   end interface
#endif
```

(4) E3SM has:

```Fortran
! With Fujitsu always abort on NaNs or INFs in input
#ifdef CPRFJ
      abort_inf_nan = .true.
#endif
```

(5) E3SM has an `#ifndef CPRFJ` around a small block of code

## Testing done

These changes have been tested extensively in E3SM.

From some limited testing in CESM, I am finding that the changes here **seem to change answers for CAM-FV cases, but not for CAM-SE**.

Specifically, here is the testing I ran, showing which baselines passed vs. failed. The pattern I see is that FV tests have baseline differences whereas SE tests do not.

```
    PASS ERS_D_Ld3.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio BASELINE cesm3_0_alpha08a:
    PASS SMS_Ld1.ne30_ne30_mg17.FC2010climo.derecho_intel.cam-outfrq1d BASELINE cesm3_0_alpha08a:
    PASS SMS_Ln9.ne30_ne30_mg17.FW2000climo.derecho_intel.cam-outfrq9s BASELINE cesm3_0_alpha08a:

    FAIL ERP_Ld3.f09_f09_mg17.FCfireHIST.derecho_intel.cam-outfrq1d BASELINE cesm3_0_alpha08a: DIFF
    FAIL ERP_Ln9.f09_f09_mg17.F2000climo.derecho_intel.cam-outfrq9s BASELINE cesm3_0_alpha08a: DIFF
    FAIL SMS_D_Ln9.f09_f09_mg17.FCHIST.derecho_intel.cam-outfrq9s_ocnemis BASELINE cesm3_0_alpha08a: DIFF
    FAIL SMS_D_Ln9.f09_f09_mg17.FCts2SD.derecho_intel.cam-outfrq9s BASELINE cesm3_0_alpha08a: DIFF
    FAIL SMS_D_Ln9.f09_f09_mg17.FWma2000climo.derecho_intel.cam-outfrq9s BASELINE cesm3_0_alpha08a: DIFF
    FAIL SMS_D_Ln9.f19_f19_mg17.FWsc2010climo.derecho_intel.cam-outfrq9s BASELINE cesm3_0_alpha08a: DIFF
    FAIL SMS_D_Ln9_P144x3.f19_f19_mg17.FC2000climo.derecho_intel.cam-outfrq9s_camchem_mam4 BASELINE cesm3_0_alpha08a: DIFF
    FAIL SMS_Ld1.f09_f09_mg17.FW2010climo.derecho_intel.cam-outfrq1d BASELINE cesm3_0_alpha08a: DIFF
```

All of those tests themselves passed.