### PR TITLE
Allow skipping checks of certain tracer variables

### DIFF
--- a/src/water_isotopes/shr_wtracers_mod.F90
+++ b/src/water_isotopes/shr_wtracers_mod.F90
@@ -186,8 +186,9 @@ contains
       if (present(variables_not_checked_in)) then
          variables_not_checked = variables_not_checked_in
       else
+         ! No variables_not_checked for this run; deallocate to clear out any setting from
+         ! previous tests.
          if (allocated(variables_not_checked)) deallocate(variables_not_checked)
-         allocate(variables_not_checked(0))
       end if
 
       water_tracers_initialized = .true.
@@ -316,8 +317,11 @@ contains
            isPresent=isPresent, isSet=isSet, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       if (.not. isPresent .or. .not. isSet .or. len_trim(cvalue) == 0) then
+         ! For typical code paths, it should never be the case that variables_not_checked
+         ! is already allocated. But check this and deallocate it to be safe in case there
+         ! is some unusual code path where it was set at one point but is no longer set -
+         ! in which case we want to clear out the old list.
          if (allocated(variables_not_checked)) deallocate(variables_not_checked)
-         allocate(variables_not_checked(0))
       else
          call shr_string_listGetAllNames(cvalue, variables_not_checked, rc=localrc)
          if (localrc /= 0) then
@@ -436,7 +440,7 @@ contains
    end subroutine shr_wtracers_print
 
    !-----------------------------------------------------------------------
-   function shr_wtracers_should_skip_check(variable_name)
+   pure function shr_wtracers_should_skip_check(variable_name)
       !
       ! !DESCRIPTION:
       ! Return true if the given variable name should skip tracer-ratio checks

--- a/src/water_isotopes/shr_wtracers_mod.F90
+++ b/src/water_isotopes/shr_wtracers_mod.F90
@@ -16,7 +16,7 @@ module shr_wtracers_mod
    !---------------------------------------------------------------------
 
    use shr_kind_mod      , only : r8=>SHR_KIND_R8
-   use shr_kind_mod      , only : CS=>SHR_KIND_CS, CM=>SHR_KIND_CM, CX=>SHR_KIND_CX, CXX=>SHR_KIND_CXX
+   use shr_kind_mod      , only : CS=>SHR_KIND_CS, CM=>SHR_KIND_CM, CL=>SHR_KIND_CL, CX=>SHR_KIND_CX, CXX=>SHR_KIND_CXX
    use shr_log_mod       , only : shr_log_error
    use shr_log_mod       , only : s_logunit=>shr_log_Unit
    use shr_log_mod       , only : s_loglev=>shr_log_Level
@@ -65,6 +65,7 @@ module shr_wtracers_mod
    private :: shr_wtracers_set_initial_ratios ! Set real-valued initial ratios from strings
    private :: shr_wtracers_print              ! Print tracer info to log
    private :: shr_wtracers_check_tracer_num   ! Check a tracer_num argument and abort if invalid
+   private :: shr_wtracers_should_skip_check  ! Return true if a variable should skip tracer-ratio checks
 
    !--------------------------------------------------------------------------
    ! Public data
@@ -97,6 +98,7 @@ module shr_wtracers_mod
    integer, allocatable :: tracer_species_types(:)
    character(len=WTRACER_SPECIES_NAME_MAXLEN), allocatable :: tracer_species_names(:)
    real(r8), allocatable :: tracer_initial_ratios(:)
+   character(len=CL), allocatable :: variables_not_checked(:)
    logical :: water_tracers_initialized = .false.
 
    character(len=*), parameter :: u_FILE_u = &
@@ -142,7 +144,8 @@ contains
 
    !-----------------------------------------------------------------------
    subroutine shr_wtracers_init_directly_for_testing( &
-              water_tracer_names, water_tracer_species, water_tracer_initial_ratios, rc)
+              water_tracer_names, water_tracer_species, water_tracer_initial_ratios, &
+              variables_not_checked_in, rc)
       !
       ! !DESCRIPTION:
       ! Initialize water tracer information directly for the sake of unit testing
@@ -153,6 +156,7 @@ contains
       character(len=*), intent(in) :: water_tracer_names(:)
       character(len=*), intent(in) :: water_tracer_species(:)  ! expected to be uppercase
       real(r8), intent(in) :: water_tracer_initial_ratios(:)
+      character(len=*), intent(in), optional :: variables_not_checked_in(:)
       integer, intent(out) :: rc
       !
       ! !LOCAL VARIABLES
@@ -178,6 +182,13 @@ contains
       call shr_wtracers_set_species_types(rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       tracer_initial_ratios = water_tracer_initial_ratios
+
+      if (present(variables_not_checked_in)) then
+         variables_not_checked = variables_not_checked_in
+      else
+         if (allocated(variables_not_checked)) deallocate(variables_not_checked)
+         allocate(variables_not_checked(0))
+      end if
 
       water_tracers_initialized = .true.
 
@@ -206,12 +217,14 @@ contains
       ! !DESCRIPTION:
       ! Parse water tracer NUOPC attributes
       !
-      ! This parses three attributes, which are all colon-delimited strings, and which all
-      ! must have the same number of elements (this requirement is checked here):
+      ! This parses four attributes, which are all colon-delimited strings, and which all
+      ! except water_tracers_variables_not_checked must have the same number of elements
+      ! (this requirement is checked here):
       ! - water_tracer_names (arbitrary user-defined names)
       ! - water_tracer_species (corresponding to predetermined strings like "H218O", or
       !   the string given by WATER_SPECIES_NAME_BULK)
       ! - water_tracer_initial_ratios (strings that are convertable to real numbers)
+      ! - water_tracers_variables_not_checked (tracer variable names for which checks should be skipped)
       !
       ! !ARGUMENTS
       type(ESMF_GridComp), intent(in) :: driver
@@ -297,6 +310,20 @@ contains
 
          call shr_wtracers_set_initial_ratios(tracer_initial_ratios_str, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
+      end if
+
+      call NUOPC_CompAttributeGet(driver, name="water_tracers_variables_not_checked", value=cvalue, &
+           isPresent=isPresent, isSet=isSet, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+      if (.not. isPresent .or. .not. isSet .or. len_trim(cvalue) == 0) then
+         if (allocated(variables_not_checked)) deallocate(variables_not_checked)
+         allocate(variables_not_checked(0))
+      else
+         call shr_string_listGetAllNames(cvalue, variables_not_checked, rc=localrc)
+         if (localrc /= 0) then
+            call shr_log_error(subname//": error processing water_tracers_variables_not_checked", rc=rc)
+            return
+         end if
       end if
 
    end subroutine shr_wtracers_parse_attributes
@@ -407,6 +434,29 @@ contains
       end if
 
    end subroutine shr_wtracers_print
+
+   !-----------------------------------------------------------------------
+   function shr_wtracers_should_skip_check(variable_name)
+      !
+      ! !DESCRIPTION:
+      ! Return true if the given variable name should skip tracer-ratio checks
+      !
+      ! !ARGUMENTS
+      character(len=*), intent(in) :: variable_name
+      logical :: shr_wtracers_should_skip_check
+      !
+      ! !LOCAL VARIABLES
+      integer :: i
+      !-----------------------------------------------------------------------
+      shr_wtracers_should_skip_check = .false.
+      if (.not. allocated(variables_not_checked)) return
+      do i = 1, size(variables_not_checked)
+         if (variables_not_checked(i) == variable_name) then
+            shr_wtracers_should_skip_check = .true.
+            return
+         end if
+      end do
+   end function shr_wtracers_should_skip_check
 
    !-----------------------------------------------------------------------
    subroutine shr_wtracers_check_tracer_num(tracer_num, subname)
@@ -658,7 +708,7 @@ contains
    end function shr_wtracers_get_initial_ratio
 
    !-----------------------------------------------------------------------
-   subroutine shr_wtracers_check_tracer_ratios_1d(tracers, bulk, name, extra_dim_index)
+   subroutine shr_wtracers_check_tracer_ratios_1d(tracers, bulk, variable_name, check_skipped, extra_dim_index)
       !
       ! !DESCRIPTION:
       ! Check tracer ratios (tracer/bulk) against expectations
@@ -669,10 +719,14 @@ contains
       ! ratios: in general, water tracers will deviate from their initial, fixed ratios,
       ! and so it makes no sense to perform these checks since they will always fail.
       !
+      ! If the given variable_name is in the list of variables to skip, the check is
+      ! skipped and check_skipped is set to true.
+      !
       ! !ARGUMENTS
       real(r8), intent(in) :: tracers(:,:)  ! dimensioned [tracerNum, gridcell]
       real(r8), intent(in) :: bulk(:)
-      character(len=*), intent(in) :: name  ! for diagnostic output
+      character(len=*), intent(in) :: variable_name  ! for diagnostic output; check is skipped if this name is in variables_not_checked
+      logical, intent(out) :: check_skipped  ! true if the check was skipped (variable_name in variables_not_checked)
       integer, intent(in), optional :: extra_dim_index  ! index of extra dimension (for error messages)
       !
       ! !LOCAL VARIABLES
@@ -688,8 +742,13 @@ contains
       ! In some error messages, it makes more sense to print the generic name:
       character(len=*), parameter :: subname_generic='shr_wtracers_check_tracer_ratios'
       !-----------------------------------------------------------------------
+      check_skipped = .false.
       if (.not. water_tracers_initialized) then
          call shr_sys_abort(subname//" ERROR: water tracers not yet initialized")
+      end if
+      if (shr_wtracers_should_skip_check(variable_name)) then
+         check_skipped = .true.
+         return
       end if
       if (size(tracers, 1) /= num_tracers) then
          write(msg, '(A,I0,A,I0)') &
@@ -737,7 +796,7 @@ contains
 
       if (.not. arrays_equal) then
          write(s_logunit, '(A,A)') subname_generic, " ERROR: tracer does not agree with bulk water"
-         write(s_logunit, '(A,A)') "Variable: ", trim(name)
+         write(s_logunit, '(A,A)') "Variable: ", trim(variable_name)
          if (present(extra_dim_index)) then
             write(s_logunit, '(A,I0)') "Extra dimension index: ", extra_dim_index
          end if
@@ -752,14 +811,14 @@ contains
          end if
          write(msg, '(A,I0)') &
               subname_generic//" ERROR: tracer does not agree with bulk water for variable '"// &
-              trim(name)//"', tracer '"//trim(tracer_names(diff_tracer))//"', at index ", diff_loc
+              trim(variable_name)//"', tracer '"//trim(tracer_names(diff_tracer))//"', at index ", diff_loc
          call shr_sys_abort(trim(msg))
       end if
 
    end subroutine shr_wtracers_check_tracer_ratios_1d
 
    !-----------------------------------------------------------------------
-   subroutine shr_wtracers_check_tracer_ratios_2d(tracers, bulk, name)
+   subroutine shr_wtracers_check_tracer_ratios_2d(tracers, bulk, variable_name, check_skipped)
       !
       ! !DESCRIPTION:
       ! Check tracer ratios (tracer/bulk) against expectations for 2-d bulk arrays
@@ -773,19 +832,29 @@ contains
       ! ratios: in general, water tracers will deviate from their initial, fixed ratios,
       ! and so it makes no sense to perform these checks since they will always fail.
       !
+      ! If the given variable_name is in the list of variables to skip, the check is
+      ! skipped and check_skipped is set to true.
+      !
       ! !ARGUMENTS
       real(r8), intent(in) :: tracers(:,:,:)  ! dimensioned [ungriddedDim, tracerNum, gridcell]
       real(r8), intent(in) :: bulk(:,:)       ! dimensioned [ungriddedDim, gridcell]
-      character(len=*), intent(in) :: name    ! for diagnostic output
+      character(len=*), intent(in) :: variable_name    ! for diagnostic output; check is skipped if this name is in variables_not_checked
+      logical, intent(out) :: check_skipped  ! true if the check was skipped (variable_name in variables_not_checked)
       !
       ! !LOCAL VARIABLES
       integer :: i
+      logical :: check_skipped_1d
       character(len=CX) :: msg
 
       character(len=*), parameter :: subname='shr_wtracers_check_tracer_ratios_2d'
       !-----------------------------------------------------------------------
+      check_skipped = .false.
       if (.not. water_tracers_initialized) then
          call shr_sys_abort(subname//" ERROR: water tracers not yet initialized")
+      end if
+      if (shr_wtracers_should_skip_check(variable_name)) then
+         check_skipped = .true.
+         return
       end if
       if (size(tracers, 1) /= size(bulk, 1)) then
          write(msg, '(A,I0,A,I0)') &
@@ -807,8 +876,13 @@ contains
       end if
 
       do i = 1, size(bulk, 1)
-         call shr_wtracers_check_tracer_ratios_1d(tracers(i,:,:), bulk(i,:), name, &
-              extra_dim_index=i)
+         call shr_wtracers_check_tracer_ratios_1d(tracers(i,:,:), bulk(i,:), variable_name, &
+              check_skipped=check_skipped_1d, extra_dim_index=i)
+         ! We set the check_skipped output to true if the check was skipped for *any* 1d
+         ! level. (In practice, this shouldn't happen unless we introduce new scenarios
+         ! where a variable is skipped, so that the pre-check at the top of this 2d
+         ! routine doesn't check all possible scenarios.)
+         if (check_skipped_1d) check_skipped = .true.
       end do
 
    end subroutine shr_wtracers_check_tracer_ratios_2d

--- a/test/unit/shr_wtracers_test/test_shr_wtracers.pf
+++ b/test/unit/shr_wtracers_test/test_shr_wtracers.pf
@@ -49,6 +49,7 @@ contains
       integer :: rc
       real(r8) :: bulk(4)
       real(r8) :: tracers(3, 4)
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -61,7 +62,8 @@ contains
       tracers(:,:) = 0._r8
 
       ! The test passes if the following call runs successfully without aborting
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_both0
 
    @Test
@@ -73,6 +75,7 @@ contains
       real(r8) :: tracers(3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -87,7 +90,8 @@ contains
       end do
 
       ! The test passes if the following call runs successfully without aborting
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_correct
 
    @Test
@@ -99,6 +103,7 @@ contains
       real(r8) :: tracers(3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -113,8 +118,9 @@ contains
       end do
       tracers(2,3) = tracers(2,3) * 1.1_r8
 
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
       @assertExceptionRaised("ABORTED: shr_wtracers_check_tracer_ratios ERROR: tracer does not agree with bulk water for variable 'test', tracer 'tracer2', at index 3")
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_differ
 
    @Test
@@ -126,6 +132,7 @@ contains
       real(r8) :: tracers(3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -140,8 +147,9 @@ contains
       end do
       tracers(2,3) = 0._r8
 
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
       @assertExceptionRaised("ABORTED: shr_wtracers_check_tracer_ratios ERROR: tracer does not agree with bulk water for variable 'test', tracer 'tracer2', at index 3")
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_tracer0
 
    @Test
@@ -153,6 +161,7 @@ contains
       real(r8) :: tracers(3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -167,8 +176,9 @@ contains
       end do
       bulk(3) = 0._r8
 
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
       @assertExceptionRaised("ABORTED: shr_wtracers_check_tracer_ratios ERROR: tracer does not agree with bulk water for variable 'test', tracer 'tracer1', at index 3")
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_bulk0
 
    @Test
@@ -180,6 +190,7 @@ contains
       real(r8) :: tracers(3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -196,7 +207,8 @@ contains
       tracers(:,3) = nan
 
       ! The test passes if the following call runs successfully without aborting
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_bothnan
 
    @Test
@@ -208,6 +220,7 @@ contains
       real(r8) :: tracers(3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -222,9 +235,77 @@ contains
       end do
       tracers(2,3) = nan
 
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
       @assertExceptionRaised("ABORTED: shr_wtracers_check_tracer_ratios ERROR: tracer does not agree with bulk water for variable 'test', tracer 'tracer2', at index 3")
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_tracernan
+
+   @Test
+   subroutine test_shr_wtracers_skiplist_other_name(this)
+      ! With a non-empty skip list that does not contain the current variable, a differing
+      ! tracer ratio should still raise an exception (and the check is not skipped)
+      !
+      ! Note that the setup for this test matches
+      ! test_shr_wtracers_check_tracer_ratios_differ, except for the setting of
+      ! variables_not_checked
+      class(TestShrWtracers), intent(inout) :: this
+      integer :: rc
+      real(r8) :: bulk(4)
+      real(r8) :: tracers(3, 4)
+      real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
+      integer :: i
+      logical :: check_skipped
+      character(len=160) :: expected_msg
+
+      call shr_wtracers_init_directly_for_testing( &
+           water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
+           water_tracer_species = [WATER_SPECIES_NAME_BULK, WATER_SPECIES_NAME_BULK, WATER_SPECIES_NAME_BULK], &
+           water_tracer_initial_ratios = ratios, &
+           variables_not_checked_in = [character(len=6) :: "other1", "other2", "other3"], &
+           rc = rc)
+      @assertEqual(ESMF_SUCCESS, rc)
+
+      bulk(:) = [1._r8, 2._r8, 3._r8, 4._r8]
+      do i = 1, 3
+         tracers(i,:) = ratios(i) * bulk(:)
+      end do
+      tracers(2,3) = tracers(2,3) * 1.1_r8
+
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      expected_msg = "ABORTED: shr_wtracers_check_tracer_ratios ERROR: tracer does not agree with bulk water for variable 'test', tracer 'tracer2', at index 3"
+      @assertExceptionRaised(expected_msg)
+      @assertFalse(check_skipped)
+   end subroutine test_shr_wtracers_skiplist_other_name
+
+   @Test
+   subroutine test_shr_wtracers_skiplist_matching_name(this)
+      ! With a skip list that contains the current variable, a differing tracer ratio
+      ! should NOT raise an exception, and check_skipped should be true
+      class(TestShrWtracers), intent(inout) :: this
+      integer :: rc
+      real(r8) :: bulk(4)
+      real(r8) :: tracers(3, 4)
+      real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
+      integer :: i
+      logical :: check_skipped
+
+      call shr_wtracers_init_directly_for_testing( &
+           water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
+           water_tracer_species = [WATER_SPECIES_NAME_BULK, WATER_SPECIES_NAME_BULK, WATER_SPECIES_NAME_BULK], &
+           water_tracer_initial_ratios = ratios, &
+           variables_not_checked_in = [character(len=6) :: "other1", "test", "other3"], &
+           rc = rc)
+      @assertEqual(ESMF_SUCCESS, rc)
+
+      bulk(:) = [1._r8, 2._r8, 3._r8, 4._r8]
+      do i = 1, 3
+         tracers(i,:) = ratios(i) * bulk(:)
+      end do
+      tracers(2,3) = tracers(2,3) * 1.1_r8
+
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      @assertTrue(check_skipped)
+   end subroutine test_shr_wtracers_skiplist_matching_name
 
    ! ------------------------------------------------------------------------
    ! Tests of shr_wtracers_check_tracer_ratios with 2-d bulk arrays
@@ -239,6 +320,7 @@ contains
       real(r8) :: tracers(2, 3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i, j
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -256,7 +338,8 @@ contains
       end do
 
       ! The test passes if the following call runs successfully without aborting
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_2d_correct
 
    @Test
@@ -268,6 +351,7 @@ contains
       real(r8) :: tracers(2, 3, 4)
       real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
       integer :: i, j
+      logical :: check_skipped
 
       call shr_wtracers_init_directly_for_testing( &
            water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
@@ -285,8 +369,47 @@ contains
       end do
       tracers(2,2,3) = tracers(2,2,3) * 1.1_r8
 
-      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test")
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
       @assertExceptionRaised("ABORTED: shr_wtracers_check_tracer_ratios ERROR: tracer does not agree with bulk water for variable 'test', tracer 'tracer2', at index 3")
+      @assertFalse(check_skipped)
    end subroutine test_shr_wtracers_check_tracer_ratios_2d_differ
+
+   @Test
+   subroutine test_shr_wtracers_skiplist_matching_name_2d(this)
+      ! With a 2-d bulk array, a differing tracer ratio should NOT raise an exception when
+      ! the variable name is in the list of variables to skip, and check_skipped should be
+      ! true
+      !
+      ! Note that the setup for this test matches
+      ! test_shr_wtracers_check_tracer_ratios_2d_differ, except for the setting of
+      ! variables_not_checked
+      class(TestShrWtracers), intent(inout) :: this
+      integer :: rc
+      real(r8) :: bulk(2, 4)
+      real(r8) :: tracers(2, 3, 4)
+      real(r8), parameter :: ratios(3) = [2._r8, 3._r8, 4._r8]
+      integer :: i, j
+      logical :: check_skipped
+
+      call shr_wtracers_init_directly_for_testing( &
+           water_tracer_names = ["tracer1", "tracer2", "tracer3"], &
+           water_tracer_species = [WATER_SPECIES_NAME_BULK, WATER_SPECIES_NAME_BULK, WATER_SPECIES_NAME_BULK], &
+           water_tracer_initial_ratios = ratios, &
+           variables_not_checked_in = [character(len=6) :: "other1", "test", "other3"], &
+           rc = rc)
+      @assertEqual(ESMF_SUCCESS, rc)
+
+      bulk(1,:) = [1._r8, 2._r8, 3._r8, 4._r8]
+      bulk(2,:) = [5._r8, 6._r8, 7._r8, 8._r8]
+      do i = 1, 3
+         do j = 1, 2
+            tracers(j,i,:) = ratios(i) * bulk(j,:)
+         end do
+      end do
+      tracers(2,2,3) = tracers(2,2,3) * 1.1_r8
+
+      call shr_wtracers_check_tracer_ratios(tracers, bulk, "test", check_skipped=check_skipped)
+      @assertTrue(check_skipped)
+   end subroutine test_shr_wtracers_skiplist_matching_name_2d
 
 end module test_shr_wtracers


### PR DESCRIPTION
There are some tracer fields that are not yet implemented properly. Allow skipping these fields when we perform tracer checks.

See billsacks/CMEPS@98cefc20e for the CMEPS change that uses this new feature. I'd like to get this share code change reviewed and merged since it's a prerequisite for the branch with that CMEPS change.

The changes here were written by Claude with my careful review.

**This depends on the CMEPS changes in https://github.com/ESCOMP/CMEPS/pull/678.**