### PR TITLE
Add module and functions for water isotope fractionation calculations

### DIFF
--- a/src/water_isotopes/CMakeLists.txt
+++ b/src/water_isotopes/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND share_sources
-  shr_wtracers_mod.F90)
+  shr_wtracers_mod.F90
+  shr_wiso_mod.F90)
 
 sourcelist_to_parent(share_sources)

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -296,17 +296,20 @@ contains
   end subroutine wiso_kmolv10
 
 !=======================================================================
-  pure function wiso_liq_vap_equil_frac_factor(isp,tk) result(equil_frac)
-!-----------------------------------------------------------------------
-! Purpose: return liquid/vapour equilibrium fractionation factor
+! Liquid/Vapor equilibrium fractionation functions
+!=======================================================================
 
-! Citation:
+  function wiso_liq_vap_equil_frac_factor(isp,tk) result(equil_frac)
 
-! Horita, J. and D. J. Wesolowski,
-! Liquid-vapor fractionation of oxygen and hydrogen isotopes of water from the freezing to the critical temperature
-! Geochimica et Cosmochimica Acta, 58, 16, August 1994
-! DOI: 10.1016/0016-7037(94)90096-5
-!-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
+    ! Public function that returns liquid/vapor equilibrium
+    ! fractionation factor given the temperature and a
+    ! water isotope (isotopologue) species index.
+    !-----------------------------------------------------------------------
+
+    use shr_kind_mod, only: cl=>shr_kind_cl
+    use shr_sys_mod,  only: shr_sys_abort
+
     ! Function input arguements
     integer , intent(in)        :: isp  ! species index
     real(r8), intent(in)        :: tk   ! Temperature (K)
@@ -314,7 +317,58 @@ contains
     ! Return value (equilibrium fractionation factor)
     real(r8) :: equil_frac
 
-    ! Local parameters
+    ! Character array to store abort error message
+    character(len=cl) :: abort_msg
+
+    !-----------------------------------------------------------------------
+
+    ! Initialize the fractionation factor to a huge negative (unphysical) value:
+    equil_frac = -huge(1._r8)
+
+    select case  (isp)
+      case(isph2o)
+        ! No fractionation for H2O
+        equil_frac = 1._r8
+      case (isphdo)
+        ! Equation 5 in Horita and Wesolowski, 1994
+        equil_frac = horita_wesolowski_frac_factor_HDO(tk)
+      case (isph218o)
+        ! Equation 6 in Horit and Wesolowski, 1994
+        equil_frac = horita_wesolowski_frac_factor_18O(tk)
+      case default
+        ! This situation shouldn't happen, so return a giant negative factor (which is unphysical)
+        !equil_frac = -huge(1._r8)
+
+        ! This situation shouldn't happen, so abort the run
+        write(abort_msg,'(a,i0)') 'wiso_liq_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = ', isp
+        call shr_sys_abort(abort_msg)
+    end select
+
+  end function wiso_liq_vap_equil_frac_factor
+
+!++++++++
+
+  pure function horita_wesolowski_frac_factor_HDO(tk) result(equil_frac_HDO)
+
+    !-----------------------------------------------------------------------
+    ! Calculate liquid/vapor equilibrium fractionation for HDO
+    !
+    ! Citation:
+    !
+    ! Equation 5 in:
+    !
+    ! Horita, J. and D. J. Wesolowski,
+    ! Liquid-vapor fractionation of oxygen and hydrogen isotopes of water from the freezing to the critical temperature
+    ! Geochimica et Cosmochimica Acta, 58, 16, August 1994
+    ! DOI: 10.1016/0016-7037(94)90096-5
+    !
+    !-----------------------------------------------------------------------
+
+    ! Function input arguements
+    real(r8), intent(in)  :: tk   ! Temperature (K)
+
+    ! Return value (HDO equilibrium fractionation factor)
+    real(r8) :: equil_frac_HDO
 
     ! Equation 5 (HDO) parameters:
     real(r8), parameter :: &
@@ -324,34 +378,54 @@ contains
       alpdl_HDO = -161.04e-3_r8, &
       alpel_HDO = 2.9992e+6_r8
 
-    ! Equation 6 (H218O) parameters:
+    !-----------------------------------------------------------------------
+
+    ! Equation 5 in Horita and Wesolowski, 1994
+    equil_frac_HDO = exp(alpal_HDO*tk**3 + alpbl_HDO*tk**2 + alpcl_HDO*tk + alpdl_HDO + alpel_HDO/tk**3)
+
+  end function horita_wesolowski_frac_factor_HDO
+
+!++++++++
+
+  pure function horita_wesolowski_frac_factor_18O(tk) result(equil_frac_18O)
+
+    !-----------------------------------------------------------------------
+    ! Calculate liquid/vapor equilibrium fractionation for H218O
+    !
+    ! Citation:
+    !
+    ! Equation 6 in:
+    !
+    ! Horita, J. and D. J. Wesolowski,
+    ! Liquid-vapor fractionation of oxygen and hydrogen isotopes of water from the freezing to the critical temperature
+    ! Geochimica et Cosmochimica Acta, 58, 16, August 1994
+    ! DOI: 10.1016/0016-7037(94)90096-5
+    !
+    !-----------------------------------------------------------------------
+
+    ! Function input arguements
+    real(r8), intent(in)  :: tk   ! Temperature (K)
+
+    ! Return value (H218O equilibrium fractionation factor)
+    real(r8) :: equil_frac_18O
+
+    ! Equation 6 (18O) parameters:
     real(r8), parameter ::       &
       alpal_18O = 0.35041e+6_r8, &
       alpbl_18O = -1.6664e+3_r8, &
       alpcl_18O = 6.7123_r8,     &
       alpdl_18O = -7.685e-3_r8
-!-----------------------------------------------------------------------
-!
-    if (isp == isph2o) then
-      ! No fractionation for H2O
-      equil_frac = 1._r8
-      return
-    end if
+    !-----------------------------------------------------------------------
 
-    if(isp == isphdo) then !HDO has a different formulation:
-      ! Equation 5 in Horita and Wesolowski, 1994
-      equil_frac = exp(alpal_HDO*tk**3 + alpbl_HDO*tk**2 + alpcl_HDO*tk + alpdl_HDO + alpel_HDO/tk**3)
-    else if(isp == isph218o) then
-      ! Equation 6 in Horit and Wesolowski, 1994
-      equil_frac = exp(alpal_18O/tk**3 + alpbl_18O/tk**2 + alpcl_18O/tk + alpdl_18O)
-    else
-      ! This situation shouldn't happen, so return a giant negative factor (which is unphysical)
-      equil_frac = -huge(1._r8)
-    end if
+    ! Equation 6 in Horita and Wesolowski, 1994
+    equil_frac_18O = exp(alpal_18O/tk**3 + alpbl_18O/tk**2 + alpcl_18O/tk + alpdl_18O)
 
-  end function wiso_liq_vap_equil_frac_factor
+  end function horita_wesolowski_frac_factor_18O
 
 !=======================================================================
+! Ice/Vapor equilibrium fractionation functions
+!=======================================================================
+
   function wiso_alpi(isp,tk)
 !-----------------------------------------------------------------------
 ! Purpose: return ice/vapour fractionation from loop-up tables

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -49,6 +49,17 @@ module shr_wiso_mod
 real(r8), parameter :: DIFF_RATIO_HDO   = 0.9757_r8
 real(r8), parameter :: DIFF_RATIO_H218O = 0.9727_r8
 
+! Diffusivity ratio for H217O relative to H216O:
+
+! Exponent value from:
+
+! Barkan, E. and B. Luz,
+! Diffusivity fractionations of HO/HO and HO/HO in air and their implications for isotope hydrology
+! Rapid Communications in Mass Spectrometry, 21, 2999-3005, August 2007
+! DOI: 10.1002/rcm.3180
+
+real(r8), parameter :: DIFF_RATIO_H217O = DIFF_RATIO_H218O**0.5185
+
 !=======================================================================
 
 contains
@@ -426,7 +437,7 @@ contains
       case (WATER_SPECIES_TYPE_H218O)
         diff_ratio = DIFF_RATIO_H218O
       case (WATER_SPECIES_TYPE_H217O)
-        diff_ratio = DIFF_RATIO_H218O !NEED TO DOUBLE-CHECK!!!!
+        diff_ratio = DIFF_RATIO_H217O
       case (WATER_SPECIES_TYPE_HDO)
         diff_ratio = DIFF_RATIO_HDO
       case default
@@ -438,7 +449,7 @@ contains
     !--------------------------
     !calculate isotopic factors
     !--------------------------
-    
+
     alpha = wiso_liq_vap_equil_frac_factor(iso,ts)  ! equilibrium frac. factor
 
     alpkn = icam_atm_ocn_kinetic_frac_factor(iso,rbot,zbot,ustar,diff_ratio) ! kinetic frac. factor
@@ -446,7 +457,7 @@ contains
     !-----------------------------------------------
     ! Merlivat and Jouzel, 1979 version
     !-----------------------------------------------
-   
+
     ! TODO:  This is basically the bulk aerodynamic formula
     !        for water isotopes.  It might be good to have
     !        some way to ensure that the bulk water fluxes
@@ -466,9 +477,9 @@ contains
   end function wiso_flxoce
 
   !=======================================================================
- 
+
   pure function icam_atm_ocn_kinetic_frac_factor(iso,rbot,zbot,ustar, diff_ratio) result(alpkn)
- 
+
   !-----------------------------------------------------------------------
   !
   ! Private function to calculate the kinetic fractionation factor for

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -20,7 +20,7 @@ module shr_wiso_mod
 ! Public interfaces
 !++++++++++++++++++
 
-  ! Generic fractionation routines (used by most/all component models):
+  ! Generic equilibrium fractionation routines (used by most/all component models):
 
   public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
   public :: wiso_ice_vap_equil_frac_factor ! Function for calculating ice/vapor equilibrium fractionation factor
@@ -29,9 +29,9 @@ module shr_wiso_mod
 
   public :: wiso_get_diffusivity_ratio     ! Function for querying the water isotope molecular diffusivity ratio
 
-  !Atmosphere-Ocean flux calculation routines (used only by the atm/ocn flux modules):
+  ! Kinetic fractionation routines (currently used only by the atm/ocn flux modules):
 
-  public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
+  public :: icam_atm_ocn_kinetic_frac_factor ! Function for calculating kinetic fractionation factor for isotopic atm/ocn fluxes.
 
 !++++++++++++++++++++++++++++++++++++++++++
 ! Physical constants for isotopic molecules
@@ -429,131 +429,18 @@ contains
 
 !=======================================================================
 
-!------------------------------
-!Atmosphere/Ocean flux routines
-!------------------------------
+!-------------------------------------
+!Kinetic fractionation functions:
+!-------------------------------------
 
 !=======================================================================
-
-  function wiso_flxoce(iso, rbot, zbot,  wtbot, &
-                       ts,  rocn, ustar, re,    &
-                       ssq, qbot, qe) result(qflx)
-
-    !-----------------------------------------------------------------------
-    !
-    ! Purpose: compute water tracer exchange from ocean
-    !
-    ! Method:
-    !   Used diagnostics output from (./dom/)flxoce to ensure
-    !   quantities are exactly equal for constituent number 1.
-    !   Isotopic fractionation (equilibrium and kinetci) is applied,
-    !   when needed.
-    !
-
-    !     E = fac (q - qs(ts))
-    !
-    !   where fac is some exchange efficiency and qs is the saturation
-    !   vapour mixing rati at the surface temperature. These are needed
-    !   from calling routine to solve isotopic equivilent.
-    !
-    !     Ei = fac (1-kmol) (qi - qs(ts)*Rocn/alpha)
-    !
-    !   To compute the kinetic drag modifneed also
-    !
-    ! Author:
-    !   David Noone <dcn@caltech.edu> - Mon Jun 30 10:24:49 MDT 2003
-    !
-    !---------------------------- Arguments --------------------------------
-    !
-
-    use shr_kind_mod, only: cl=>shr_kind_cl
-    use shr_sys_mod,  only: shr_sys_abort
-
-    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
-    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
-    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
-    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
-
-    integer , intent(in)  :: iso   ! isotope species index
-    real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
-    real(r8), intent(in)  :: zbot  ! height of lowest level (m)
-    real(r8), intent(in)  :: wtbot ! constituents at lowest
-    real(r8), intent(in)  :: qbot  ! bulk water (q) at lowest
-    real(r8), intent(in)  :: qe    ! bulk evaporative flux (evp)
-
-    real(r8), intent(in)  :: ts    ! (sea) surface temperature K
-    real(r8), intent(in)  :: rocn  ! (sea) surface isotope ratio
-    real(r8), intent(in)  :: ustar ! friction velocity (m/s)
-    real(r8), intent(in)  :: re    ! Reynolds number
-    real(r8), intent(in)  :: ssq   ! s.hum. saturation at Ts
-
-    real(r8) :: qflx               ! water tracer flux (kg/kg/s) <-- return value
-
-    ! Local variables
-    real(r8) diff_ratio                   ! isotopic diffusivities ratio
-    real(r8) alpkn                        ! kinetic fractionation efficiency (m)
-    real(r8) delq                         ! spec. hum. difference
-    real(r8) alpha                        ! fractionation factor
-
-    ! Character array to store abort error message
-    character(len=cl) :: abort_msg
-    !-----------------------------------------------------------------------
-
-    !Check that the provided isotopic species is valid:
-    select case  (iso)
-      case(WATER_SPECIES_TYPE_BULK)
-        ! No kinetic fractionation for H2O
-        diff_ratio = 1._r8
-      case (WATER_SPECIES_TYPE_H218O)
-        diff_ratio = DIFF_RATIO_H218O
-      case (WATER_SPECIES_TYPE_H217O)
-        diff_ratio = DIFF_RATIO_H217O
-      case (WATER_SPECIES_TYPE_HDO)
-        diff_ratio = DIFF_RATIO_HDO
-      case default
-        ! This situation shouldn't happen, so abort the run
-        write(abort_msg,'(a,i0)') 'wiso_flxoce: ERROR: bad isotope species index; bad index = ', iso
-        call shr_sys_abort(abort_msg)
-    end select
-
-    !--------------------------
-    !calculate isotopic factors
-    !--------------------------
-
-    alpha = wiso_liq_vap_equil_frac_factor(iso,ts)  ! equilibrium frac. factor
-
-    alpkn = icam_atm_ocn_kinetic_frac_factor(iso,rbot,zbot,ustar,diff_ratio) ! kinetic frac. factor
-
-    !-----------------------------------------------
-    ! Merlivat and Jouzel, 1979 version
-    !-----------------------------------------------
-
-    ! TODO:  This is basically the bulk aerodynamic formula
-    !        for water isotopes.  It might be good to have
-    !        some way to ensure that the bulk water fluxes
-    !        are also using a similar formula, and if not
-    !        to adjust this calculation in order to ensure
-    !        that the isotopic fluxes are physically consistent
-    !    with the bulk fluxes.
-
-    ! Compute the vapour deficit between the atmosphere
-    ! and the "saturated" layer
-    ! just above the ocean surface.
-    delq  = wtbot - ssq*rocn/alpha
-
-    ! Calculate final isotopic flux value
-    qflx = rbot*ustar*alpkn*re*delq
-
-  end function wiso_flxoce
-
-  !=======================================================================
 
   pure function icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustar, diff_ratio) result(alpkn)
 
   !-----------------------------------------------------------------------
   !
-  ! Private function to calculate the kinetic fractionation factor for
-  ! ocean evaporation, as used in the original iCAM5 implementation.
+  ! Function to calculate the kinetic fractionation factor for
+  ! ocean evaporation/condensation, as used in the original iCAM5 implementation.
   !
   ! Citation:
   !
@@ -600,9 +487,9 @@ contains
     real(r8), parameter :: recrit   = 1.0_r8  ! critical Reynolds number for kmol
     !-----------------------------------------------------------------------
 
-    vmu = muair / rbot                    ! kinematic viscosity
-    Sc  = vmu/difair                      ! Schmidt number
-    reno = ustar*zoq / vmu                ! Reynolds number
+    vmu = muair / rbot          ! kinematic viscosity
+    Sc  = vmu / difair          ! Schmidt number
+    reno = ustar*zoq / vmu      ! Reynolds number
 
     if (reno < recrit) then ! Smooth regime (Re < 0.13)
       enn = 2._r8/3._r8

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -35,14 +35,11 @@ module shr_wiso_mod
   public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
   public :: wiso_ice_vap_equil_frac_factor ! Function for calculating ice/vapor equilibrium fractionation factor
   public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
-  public :: wiso_akel            ! kinetic fractionation at liq. evaporation
-  public :: wiso_akci            ! kinetic fractnation at ice condensation
 
   !Calculation routines:
 
   public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
   public :: wiso_ssatf           ! supersaturation function
-  public :: wiso_heff            ! effective humidity function
 
   !Data checking routines:
 
@@ -124,16 +121,6 @@ module shr_wiso_mod
       aksmc = (/ 0._r8, 0._r8, 0.00528_r8,   0.006_r8    /), &
       akrfa = (/ 0._r8, 0._r8, 0.2508e-3_r8, 0.285e-3_r8 /), &
       akrfb = (/ 0._r8, 0._r8, 0.7216e-3_r8, 0.82e-3_r8  /)
-
-! Interface definition for H218O equilibirum fractionation function,
-! so that the functions can then be passed into the H217O fractionation function.
-  abstract interface
-    pure function H218O_equil_func(tk) result(equil_frac_18O)
-      use, intrinsic :: iso_fortran_env, only: real64
-      real(real64), intent(in) :: tk ! Temperature (K)
-      real(real64) :: equil_frac_18O
-    end function
-  end interface
 
 contains
 
@@ -232,6 +219,9 @@ contains
     ! Return value (equilibrium fractionation factor)
     real(r8) :: equil_frac
 
+    ! Local variable to save 18O fractionation factor for 17O calculation
+    real(r8) :: alpha_18O
+
     ! Character array to store abort error message
     character(len=cl) :: abort_msg
 
@@ -248,8 +238,10 @@ contains
         ! Equation 6 in Horita and Wesolowski, 1994
         equil_frac = horita_wesolowski_frac_factor_18O(tk)
       case (WATER_SPECIES_TYPE_H217O)
+        ! Equation 6 in Horita and Wesolowski, 1994
+        alpha_18O = horita_wesolowski_frac_factor_18O(tk)
         ! Equation 3 from Barkan and Luz, 2005
-        equil_frac = barkan_luz_frac_factor_17O(tk, horita_wesolowski_frac_factor_18O)
+        equil_frac = barkan_luz_frac_factor_17O(alpha_18O)
       case (WATER_SPECIES_TYPE_HDO)
         ! Equation 5 in Horita and Wesolowski, 1994
         equil_frac = horita_wesolowski_frac_factor_HDO(tk)
@@ -359,6 +351,9 @@ contains
     ! Return value (equilibrium fractionation factor)
     real(r8) :: equil_frac
 
+    ! Local variable to save 18O fractionation factor for 17O calculation
+    real(r8) :: alpha_18O
+
     ! Character array to store abort error message
     character(len=cl) :: abort_msg
 
@@ -375,8 +370,10 @@ contains
         ! Equation from Majoube, 1971
         equil_frac = majoube_frac_factor_18O(tk)
       case (WATER_SPECIES_TYPE_H217O)
+        ! 18O fractionation factor from Majoube, 1971
+        alpha_18O = majoube_frac_factor_18O(tk)
         ! Equation 3 from Barkan and Luz, 2005
-        equil_frac = barkan_luz_frac_factor_17O(tk, majoube_frac_factor_18O)
+        equil_frac = barkan_luz_frac_factor_17O(alpha_18O)
       case (WATER_SPECIES_TYPE_HDO)
         ! Equation 5 in Merlivat and Nief, 1967
         equil_frac = merlivat_nief_frac_factor_HDO(tk)
@@ -462,10 +459,11 @@ contains
 ! H217O equilibrium fractionation function
 !=======================================================================
 
-  pure function barkan_luz_frac_factor_17O(tk, equil_func_18O) result(equil_frac_17O)
+  pure function barkan_luz_frac_factor_17O(equil_factor_18O) result(equil_frac_17O)
 
     !-----------------------------------------------------------------------
-    ! Calculate equilibrium fractionation factor for H217O (all phase changes)
+    ! Calculate equilibrium fractionation factor for H217O (all phase changes),
+    ! given the H218O equilibrium fraction factor.
     !
     ! Citation:
     !
@@ -479,8 +477,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Function input arguements
-    real(r8), intent(in) :: tk                    ! Temperature (K)
-    procedure(H218O_equil_func) :: equil_func_18O ! Function to calculate 18O equilibrium fractionation
+    real(r8), intent(in) :: equil_factor_18O      ! Equilibrium fractionation factor for H218O.
 
     ! Return value (H217O equilibrium fractionation factor)
     real(r8) :: equil_frac_17O
@@ -490,78 +487,11 @@ contains
 
     !-----------------------------------------------------------------------
 
-    equil_frac_17O = equil_func_18O(tk)**theta
+    equil_frac_17O = equil_factor_18O**theta
 
-  end function barkan_luz_frac_factor_17O 
-
-!=======================================================================
-function wiso_akel(isp,tk,hum0,alpeq)
-!-----------------------------------------------------------------------
-! Purpose: return modified fractination for kinetic effects during
-!          liquid evaporation into unsaturated air.
-! Author:  David Noone <dcn@caltech.edu> - Tue Jul  1 12:02:24 MDT 2003
-!-----------------------------------------------------------------------
-    integer , intent(in)        :: isp   ! species indes
-    real(r8), intent(in)        :: tk    ! Temperature (K)
-    real(r8), intent(in)        :: hum0  ! initial humidity ()
-    real(r8), intent(in)        :: alpeq ! equilibrium fractionation factor
-    real(r8) :: wiso_akel                ! return effective fractionation
-    real(r8) :: h0                       ! humidity
-    real(r8) :: heff                     ! effective humidity
-    real(r8) :: difrmj                   ! diffusivity for iso. sub. hum.
-    real(r8) :: dondi                    ! (D / Di)^fdif, (rather than Di/D)
-!-----------------------------------------------------------------------
-!!    if (tk > tkinl) then              ! also do it for supercooled water
-      h0 = min(1.0_r8,hum0)
-!!      difrmj = difrm(isp)/fisub(isp)
-      difrmj = difrm(isp)
-      heff = wiso_heff(h0)
-      dondi = (1/difrmj)**dkfac
-      wiso_akel = alpeq*heff / (alpeq*dondi*(heff-1._r8) + 1._r8)
-!!    else
-!!      wiso_akel = alpeq
-!!    end if
-!
-! Modify for non-standard isotope
-!
-!!    wiso_akel = wiso_akel**expk(isp)
-
-    return
-end function wiso_akel
+  end function barkan_luz_frac_factor_17O
 
 !=======================================================================
-  function wiso_akci(isp,tk,alpeq)
-!-----------------------------------------------------------------------
-! Purpose: return modified fractination for kinetic effects during
-!          condensation to ice.
-!          Make use of supersaturation function.
-! Author:  David Noone <dcn@caltech.edu> - Tue Jul  1 12:02:24 MDT 2003
-!-----------------------------------------------------------------------
-    integer , intent(in)        :: isp   ! species indes
-    real(r8), intent(in)        :: tk    ! temperature (k)
-    real(r8), intent(in)        :: alpeq ! equilibrium fractionation factor
-    real(r8) :: wiso_akci               ! return effective fractionation
-    real(r8) :: sat1                    ! super sturation
-    real(r8) :: difrmj                  ! isotopic diffusion for subs. molec.
-    real(r8) :: dondi                   ! D / Di, (rather than Di/D)
-!-----------------------------------------------------------------------
-!
-    if (tk < tkini) then                ! anytime below freezing
-      sat1 = max(1._r8, wiso_ssatf(tk))
-!!      difrmj = difrm(isp)/fisub(isp)
-      difrmj = difrm(isp)
-      dondi = 1._r8/difrmj
-      wiso_akci = alpeq*sat1 / (alpeq*dondi*(sat1-1._r8) + 1._r8)
-    else
-      wiso_akci = alpeq
-    end if
-!
-! Modify for non-standard isotope
-!
-!!    wiso_akci = wiso_akci**expk(isp)
-!
-    return
-end function wiso_akci
 
 !--------------------
 !Calculation routines
@@ -680,19 +610,6 @@ end function wiso_akci
 
   return
 end subroutine wiso_flxoce
-
-!=======================================================================
- function wiso_heff(h0)
-!-----------------------------------------------------------------------
-! Purpose: Compute effective humidity (Jouzel type thing)
-! Author: David Noone <dcn@caltech.edu> - Fri Oct 24 12:06:55 PDT 2003
-!-----------------------------------------------------------------------
-    real(r8), intent(in)  :: h0       ! initial humidity
-    real(r8) :: wiso_heff             ! return humidity (subsaturation)
-!-----------------------------------------------------------------------
-    wiso_heff = min(1.0_r8, fkhum*h0 + 1.0_r8-fkhum)
-    return
-end function wiso_heff
 
 !=======================================================================
 function wiso_ssatf(tk)

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -32,7 +32,6 @@ module shr_wiso_mod
   !Atmosphere-Ocean flux calculation routines (used only by the atm/ocn flux modules):
 
   public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
-  public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
 
 !++++++++++++++++++++++++++++++++++++++++++
 ! Physical constants for isotopic molecules
@@ -360,205 +359,180 @@ contains
 
 !=======================================================================
 
- subroutine wiso_flxoce( iso  ,rbot   ,zbot   ,wtbot   , &
-                         ts     , rocn, ustar  ,re , &
-                        ssq, qflx, qbot, qe )
+  function wiso_flxoce(iso, rbot, zbot,  wtbot, &
+                       ts,  rocn, ustar, re,    &
+                       ssq, qbot, qe) result(qflx)
 
-!-----------------------------------------------------------------------
-!
-! Purpose: compute water tracer exchange from ocean
-!
-! Method:
-!   Used diagnostics output from (./dom/)flxoce to ensure
-!   quantities are exactly equal for constituent number 1.
-!   Isotopic fractionation (equilibrium and kinetci) is applied,
-!   when needed.
-!
+    !-----------------------------------------------------------------------
+    !
+    ! Purpose: compute water tracer exchange from ocean
+    !
+    ! Method:
+    !   Used diagnostics output from (./dom/)flxoce to ensure
+    !   quantities are exactly equal for constituent number 1.
+    !   Isotopic fractionation (equilibrium and kinetci) is applied,
+    !   when needed.
+    !
 
-!     E = fac (q - qs(ts))
-!
-!   where fac is some exchange efficiency and qs is the saturation
-!   vapour mixing rati at the surface temperature. These are needed
-!   from calling routine to solve isotopic equivilent.
-!
-!     Ei = fac (1-kmol) (qi - qs(ts)*Rocn/alpha)
-!
-!   To compute the kinetic drag modifneed also
-!
-! Author:
-!   David Noone <dcn@caltech.edu> - Mon Jun 30 10:24:49 MDT 2003
-!
-!   Ported to CAM5, and added Schmidt, 1999 scheme - Jesse Nusbaumer <nusbaume@colorado.edu> - April, 2012
-!
-!-----------------------------------------------------------------------
-!  use shr_kind_mod, only: r8 => shr_kind_r8
-!  use water_tracers, only: trace_water, wtrc_is_vap, iwspec, ixwti, ixwtx
-!  use water_isotopes, only: wisotope, wiso_kmol, &
-!                              wiso_alpi
+    !     E = fac (q - qs(ts))
+    !
+    !   where fac is some exchange efficiency and qs is the saturation
+    !   vapour mixing rati at the surface temperature. These are needed
+    !   from calling routine to solve isotopic equivilent.
+    !
+    !     Ei = fac (1-kmol) (qi - qs(ts)*Rocn/alpha)
+    !
+    !   To compute the kinetic drag modifneed also
+    !
+    ! Author:
+    !   David Noone <dcn@caltech.edu> - Mon Jun 30 10:24:49 MDT 2003
+    !
+    !---------------------------- Arguments --------------------------------
+    !
 
-  implicit none
+    use shr_kind_mod, only: cl=>shr_kind_cl
+    use shr_sys_mod,  only: shr_sys_abort
 
-!---------------------------- Arguments --------------------------------
-!
-   integer , intent(in)  :: iso    ! isotope value (1=16O,2=D,3=18O)
-  real(r8), intent(in)  :: rbot    ! density of lowest layer (kg/m3)
-  real(r8), intent(in)  :: zbot    ! height of lowest level (m)
-  real(r8), intent(in)  :: wtbot   ! constituents at lowest
-  real(r8), intent(in)  :: qbot    ! bulk water (q) at lowest
-  real(r8), intent(in)  :: qe      ! bulk evaporative flux (evp)
+    integer , intent(in)  :: iso   ! isotope species index
+    real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
+    real(r8), intent(in)  :: zbot  ! height of lowest level (m)
+    real(r8), intent(in)  :: wtbot ! constituents at lowest
+    real(r8), intent(in)  :: qbot  ! bulk water (q) at lowest
+    real(r8), intent(in)  :: qe    ! bulk evaporative flux (evp)
 
-  real(r8), intent(in)  :: ts    ! (sea) surface temperature K
-  real(r8), intent(in)  :: rocn  ! (sea) surface temperature iso ratio/Rstd
-  real(r8), intent(in)  :: ustar ! friction velocity (m/s)
-  real(r8), intent(in)  :: re    ! Reynolds number ?
-  real(r8), intent(in)  :: ssq   ! s.hum. saturation at Ts
-!
-  real(r8), intent(out) :: qflx ! constituentflux (kg/kg/s)
-!
-!------------------------- Local Variables -----------------------------
-  real(r8) alpkn                        ! kinetic fractionation efficiency (m)
-  real(r8) tau                          ! stress
-  real(r8) delq                         ! spec. hum. difference
-  real(r8) qstar                        ! spec. hum,. mixing scale
-  real(r8) Roce                         ! water tracer ratio of ocean surface
-  real(r8) alpha                        ! fractionation factor
-  real(r8) R_std                        ! tracer ratio in evaporation
-!-----------------------------------------------------------------------
-!
-!--------------------------
-!calculate isotopic factors
-!--------------------------
-!
-  alpha = wiso_liq_vap_equil_frac_factor(iso,ts)  !get equilibrium frac. factor
-  call wiso_kmol(iso,rbot,zbot,ustar,alpkn)            !Advanced kinetic frac. routine
+    real(r8), intent(in)  :: ts    ! (sea) surface temperature K
+    real(r8), intent(in)  :: rocn  ! (sea) surface isotope ratio
+    real(r8), intent(in)  :: ustar ! friction velocity (m/s)
+    real(r8), intent(in)  :: re    ! Reynolds number
+    real(r8), intent(in)  :: ssq   ! s.hum. saturation at Ts
 
-  if(rocn .eq. 0._r8) then                             !no ocean model data:
-  ! Need to get 'roce' or 'rstd' from shr_wtracers_mod.
-    !    Roce = wiso_get_rstd(iso)                          !set to default value
-  else                                                 !isotopic ocean model present:
-!    R_std = wiso_get_rstd(iso)                         !pull ratio from ocean data
-!    Roce = R_std*rocn
-  end if                                               !rocn value
-!
-!-----------------------------------------------
-!David Noone (Merlivat and Jouzel, 1979) version
-!-----------------------------------------------
-!
-! Compute the vapour deficit then, get the fluxes
-!
-        delq  = wtbot - ssq*Roce/alpha
+    real(r8) :: qflx               ! water tracer flux (kg/kg/s) <-- return value
 
-        qstar = re*delq
-        tau   = rbot * ustar * ustar
+    ! Local variables
+    real(r8) diff_ratio                   ! isotopic diffusivities ratio
+    real(r8) alpkn                        ! kinetic fractionation efficiency (m)
+    real(r8) delq                         ! spec. hum. difference
+    real(r8) alpha                        ! fractionation factor
 
-        qflx = tau*alpkn*qstar/ustar
-!
-!---------------------
-!Schmidt, 1999 version
-!---------------------
-!
-!         rh = qbot/ssq                                         !calculate relative humidity
-!
-!If RH is 100%, then assume no evaporation occurs (although isotopic equilibration does, which needs to be coded in)
-!
-!         if(rh /= 1) then
-!           Rate = alpkn*(Roce/alpha - (rh*wtbot/qbot))/(1-rh)  !calculate ratio in flux
-!         else
-!           Rate = 0                                            !Assume no evaporation occurs if RH is 100%
-!         end if
-!
-!         qflx = Rate*qe                                        !convert to specific humidity (qi)
+    ! Character array to store abort error message
+    character(len=cl) :: abort_msg
+    !-----------------------------------------------------------------------
 
-  return
-end subroutine wiso_flxoce
+    !Check that the provided isotopic species is valid:
+    select case  (iso)
+      case(WATER_SPECIES_TYPE_BULK)
+        ! No kinetic fractionation for H2O
+        diff_ratio = 1._r8
+      case (WATER_SPECIES_TYPE_H218O)
+        diff_ratio = DIFF_RATIO_H218O
+      case (WATER_SPECIES_TYPE_H217O)
+        diff_ratio = DIFF_RATIO_H218O !NEED TO DOUBLE-CHECK!!!!
+      case (WATER_SPECIES_TYPE_HDO)
+        diff_ratio = DIFF_RATIO_HDO
+      case default
+        ! This situation shouldn't happen, so abort the run
+        write(abort_msg,'(a,i0)') 'wiso_flxoce: ERROR: bad isotope species index; bad index = ', iso
+        call shr_sys_abort(abort_msg)
+    end select
 
-!=======================================================================
-  subroutine wiso_kmol(isp,rbot,zbot,ustar,alpkn)
-!-----------------------------------------------------------------------
-!
-! Purpose: compute kinetic modifier for drag coefficient (Merlivat & Jouzel)
-!
-! Method:
-!   Code solves Brutsaert equations for theturbulent layer using GCM computed
-!   quantities.  Operates on a vector of points.
-!
-! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 14:05:38 MDT 2003
-!
-!-----------------------------------------------------------------------
-    use shr_kind_mod,  only: r8 => shr_kind_r8
-    use shr_kind_mod,  only: cl => shr_kind_cl
-    use shr_const_mod, only: shr_const_g, shr_const_karman
-    use shr_sys_mod,   only: shr_sys_abort
+    !--------------------------
+    !calculate isotopic factors
+    !--------------------------
+    
+    alpha = wiso_liq_vap_equil_frac_factor(iso,ts)  ! equilibrium frac. factor
 
-    implicit none
+    alpkn = icam_atm_ocn_kinetic_frac_factor(iso,rbot,zbot,ustar,diff_ratio) ! kinetic frac. factor
+
+    !-----------------------------------------------
+    ! Merlivat and Jouzel, 1979 version
+    !-----------------------------------------------
+   
+    ! TODO:  This is basically the bulk aerodynamic formula
+    !        for water isotopes.  It might be good to have
+    !        some way to ensure that the bulk water fluxes
+    !        are also using a similar formula, and if not
+    !        to adjust this calculation in order to ensure
+    !        that the isotopic fluxes are physically consistent
+    !    with the bulk fluxes.
+
+    ! Compute the vapour deficit between the atmosphere
+    ! and the "saturated" layer
+    ! just above the ocean surface.
+    delq  = wtbot - ssq*rocn/alpha
+
+    ! Calculate final isotopic flux value
+    qflx = rbot*ustar*alpkn*re*delq
+
+  end function wiso_flxoce
+
+  !=======================================================================
+ 
+  pure function icam_atm_ocn_kinetic_frac_factor(iso,rbot,zbot,ustar, diff_ratio) result(alpkn)
+ 
+  !-----------------------------------------------------------------------
+  !
+  ! Private function to calculate the kinetic fractionation factor for
+  ! ocean evaporation, as used in the original iCAM5 implementation.
+  !
+  ! Citation:
+  !
+  ! Equations 4 to 10 in:
+  !
+  ! Nusbaumer, J., Wong, T. E., Bardeen, C., and D. Noone.
+  ! Evaluating hydrological processes in the Community Atmosphere Model Version 5 (CAM5)
+  ! using stable isotope ratios of water
+  ! Journal of Advances in Modeling Earth Systems, 9, 2, 949-977, June 2017
+  ! DOI: 10.1002/2016MS000839
+  !
+  !-----------------------------------------------------------------------
+    use shr_const_mod, only: gravit=>shr_const_g
+    use shr_const_mod, only: karman=>shr_const_karman
 
     real(r8), parameter :: difair = 2.36e-5_r8          ! molecular diffusivity of air
     real(r8), parameter :: muair  = 1.7e-5_r8           ! dynamic viscosity of air
-                                                     ! about 17 degC, 1.73 at STP (Salby)
-    real(r8), parameter :: gravit = shr_const_g      ! gravity
-    real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
+                                                        ! about 17 degC, 1.73 at STP (Salby)
 
-!---------------------------- Arguments --------------------------------
-    integer , intent(in)  :: isp   ! species flag
+    !---------------------------- Arguments --------------------------------
+    integer , intent(in)  :: iso   ! species flag
     real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
     real(r8), intent(in)  :: zbot  ! height of lowest level (m)
     real(r8), intent(in)  :: ustar ! Friction velocity (m/s)
-!
-    real(r8), intent(out) :: alpkn ! kinetic fractionation factor (1-kmol)
+    real(r8), intent(in)  :: diff_ratio ! isotopic diffusion ratio
 
-!------------------------- Local Variables -----------------------------
+    real(r8) :: alpkn ! kinetic fractionation factor (1-kmol)
+
+    !------------------------- Local Variables -----------------------------
     real(r8) z0                 ! roughness length (constant in cam 9.5e-5)
     real(r8) reno               ! surface reynolds number
-    real(r8) tmr                ! ratio of turbulen to molecular resistance
+    real(r8) tmr                ! ratio of turbulent to molecular resistance
     real(r8) enn                ! diffusive power
     real(r8) sc                 ! Schmidt number (Prandtl number)
     real(r8) vmu                ! kinematic viscocity of air
     real(r8) difn               ! ratio of difusivities to the power of n
-    real(r8) difrmj             ! isotopic diffusion with substitutions
+    real(r8) kmol               ! Merlivat'ss "k_mol"
 
-    real(r8) kmol               ! Merlivals k_mol
+    real(r8), parameter :: recrit   = 1.0_r8  ! critical Reynolds number for kmol
+    !-----------------------------------------------------------------------
 
-    ! Character array to store abort error message
-    character(len=cl) :: abort_msg
+    z0 = (ustar**2._r8)/(81.1_r8*gravit)  ! Charnock's equation
+    vmu = muair / rbot                    ! kinematic viscosity
+    Sc  = vmu/difair                      ! Schmidt number
+    reno = ustar*z0 / vmu                 ! Reynolds number
 
-    real(r8), parameter :: recrit   = 1.0_r8  ! critical raynolds number for kmol
-!-----------------------------------------------------------------------
-!
-    select case  (isp)
-      case(WATER_SPECIES_TYPE_BULK)
-        ! No kinetic fractionation for H2O
-        difrmj = 1._r8
-      case (WATER_SPECIES_TYPE_H218O)
-        difrmj = DIFF_RATIO_H218O
-      case (WATER_SPECIES_TYPE_H217O)
-        difrmj = DIFF_RATIO_H218O !NEED TO DOUBLE-CHECK!!!!
-      case (WATER_SPECIES_TYPE_HDO)
-        difrmj = DIFF_RATIO_HDO
-      case default
-        ! This situation shouldn't happen, so abort the run
-        write(abort_msg,'(a,i0)') 'wiso_kmol: ERROR: bad isotope species index; bad index = ', isp
-        call shr_sys_abort(abort_msg)
-    end select
-!
-      z0 = (ustar**2._r8)/(81.1_r8*gravit)  ! Charnock's equation
-      vmu = muair / rbot             ! kinematic viscosity
-      Sc  = vmu/difair
-      reno = ustar*z0 / vmu       ! reynolds number
-!
-      if (reno < recrit) then        ! Smooth (Re < 0.13)
-         enn = 2._r8/3._r8
-         tmr  = ( (1._r8/karman)*log(ustar*zbot / (30._r8 * vmu)) ) / (13.6_r8 * Sc**(2._r8/3._r8))
-      else                           ! Rough  (Re > 2)
-         enn = 1._r8/2._r8
-         tmr  = ( (1._r8/karman)*log(zbot/z0) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
-      end if
+    if (reno < recrit) then ! Smooth regime (Re < 0.13)
+      enn = 2._r8/3._r8
+      tmr  = ( (1._r8/karman)*log(ustar*zbot / (30._r8 * vmu)) ) / (13.6_r8 * Sc**(2._r8/3._r8))
+    else                    ! Rough regime (Re > 2)
+      enn = 1._r8/2._r8
+      tmr  = ( (1._r8/karman)*log(zbot/z0) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
+    end if
 
-      difn = (1._r8/difrmj)**enn        ! use D/Di, not Di/D
-      kmol = (difn - 1._r8) / (difn + tmr)
+    difn = (1._r8/diff_ratio)**enn        ! use D/Di, not Di/D
+    kmol = (difn - 1._r8) / (difn + tmr)
 
-      alpkn = 1._r8 - kmol
+    alpkn = 1._r8 - kmol
 
-  end subroutine wiso_kmol
+  end function icam_atm_ocn_kinetic_frac_factor
 
 !=========================================================================
 end module shr_wiso_mod

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -45,7 +45,7 @@ module shr_wiso_mod
 
   !Fractionation routines:
 
-  public :: wiso_alpl            ! look-up liquid/vapor equil. fractn.
+  public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
   public :: wiso_alpi            ! look-up ice/vapor equil. fractn.
   public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
   public :: wiso_kmolv10         ! kmol (as above) from 10 meter wind (M&J)
@@ -322,36 +322,60 @@ contains
   end subroutine wiso_kmolv10
 
 !=======================================================================
-  function wiso_alpl(isp,tk)
+  pure function wiso_liq_vap_equil_frac_factor(isp,tk) result(equil_frac)
 !-----------------------------------------------------------------------
-! Purpose: return liquid/vapour fractionation from look-up tables
-! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 10:59:13 MDT 2003
+! Purpose: return liquid/vapour equilibrium fractionation factor
+
+! Citation:
+
+! Horita, J. and D. J. Wesolowski,
+! Liquid-vapor fractionation of oxygen and hydrogen isotopes of water from the freezing to the critical temperature
+! Geochimica et Cosmochimica Acta, 58, 16, August 1994
+! DOI: 10.1016/0016-7037(94)90096-5
 !-----------------------------------------------------------------------
-    integer , intent(in)        :: isp  ! species indes
-    real(r8), intent(in)        :: tk    ! temperature (k)
-    real(r8) :: wiso_alpl               ! return fractionation
+    ! Function input arguements
+    integer , intent(in)        :: isp  ! species index
+    real(r8), intent(in)        :: tk   ! Temperature (K)
+
+    ! Return value (equilibrium fractionation factor)
+    real(r8) :: equil_frac
+
+    ! Local parameters
+
+    ! Equation 5 (HDO) parameters:
+    real(r8), parameter :: &
+      alpal_HDO = 1158.8e-12_r8, &
+      alpbl_HDO = -1620.1e-9_r8, &
+      alpcl_HDO = 794.84e-6_r8, &
+      alpdl_HDO = -161.04e-3_r8, &
+      alpel_HDO = 2.9992e+6_r8
+
+    ! Equation 6 (H218O) parameters:
+    real(r8), parameter ::       &
+      alpal_18O = 0.35041e+6_r8, &
+      alpbl_18O = -1.6664e+3_r8, &
+      alpcl_18O = 6.7123_r8,     &
+      alpdl_18O = -7.685e-3_r8
 !-----------------------------------------------------------------------
 !
     if (isp == isph2o) then
-      wiso_alpl = 1._r8
+      ! No fractionation for H2O
+      equil_frac = 1._r8
       return
     end if
-!Majoube, 1971:
-!    wiso_alpl = exp(alpal(isp)/tk**2 + alpbl(isp)/tk + alpcl(isp))
 
-!Horita and Wesolowski, 1994:
-    if(isp == isphdo) then !HDO has different formulation:
-      wiso_alpl = exp(alpal(isp)*tk**3 + alpbl(isp)*tk**2 + alpcl(isp)*tk + alpdl(isp) + alpel(isp)/tk**3)
+    if(isp == isphdo) then !HDO has a different formulation:
+      ! Equation 5 in Horita and Wesolowski, 1994
+      equil_frac = exp(alpal_HDO*tk**3 + alpbl_HDO*tk**2 + alpcl_HDO*tk + alpdl_HDO + alpel_HDO/tk**3)
+    else if(isp == isph218o) then
+      ! Equation 6 in Horit and Wesolowski, 1994
+      equil_frac = exp(alpal_18O/tk**3 + alpbl_18O/tk**2 + alpcl_18O/tk + alpdl_18O)
     else
-      wiso_alpl = exp(alpal(isp)/tk**3 + alpbl(isp)/tk**2 + alpcl(isp)/tk + alpdl(isp))
+      ! This situation shouldn't happen, so return a giant negative factor (which is unphysical)
+      equil_frac = -huge(1._r8)
     end if
 
-#ifdef NOFRAC
-    wiso_alpl = 1._r8
-#endif
-!
-    return
-  end function wiso_alpl
+  end function wiso_liq_vap_equil_frac_factor
 
 !=======================================================================
   function wiso_alpi(isp,tk)
@@ -508,7 +532,7 @@ end function wiso_akci
 !-----------------------------------------------------------------------
 !  use shr_kind_mod, only: r8 => shr_kind_r8
 !  use water_tracers, only: trace_water, wtrc_is_vap, iwspec, ixwti, ixwtx
-!  use water_isotopes, only: wisotope, wiso_kmol, wiso_alpl,wiso_get_roce, &
+!  use water_isotopes, only: wisotope, wiso_kmol, wiso_get_roce, &
 !                              wiso_alpi
 
   implicit none
@@ -544,7 +568,7 @@ end function wiso_akci
 !calculate isotopic factors
 !--------------------------
 !
-  alpha = wiso_alpl(iso,ts)                            !get equilibrium frac. factor
+  alpha = wiso_liq_vap_equil_frac_factor(iso,ts)  !get equilibrium frac. factor
  ! call wiso_kmolv10(iso,ustar,alpkn)                   !get kinetic frac. factor
   call wiso_kmol(iso,rbot,zbot,ustar,alpkn)            !Advanced kinetic frac. routine
 

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -1,0 +1,712 @@
+module shr_wiso_mod
+!-----------------------------------------------------------------------
+!
+! Provides the functions and constants needed to calculate the isotopc flux from
+! water on the ocean surface into the atmosphere.
+!
+! All interface routine are identified by wiso_*, etc.
+!
+! This code works over species indices, rather than the constituent indices
+! used in the water_tracers module. As such, MAKE SURE you call these
+! routines with species indicies! The tracer variable names do not need to
+! match the species names, which are privided just for diagnostic output.
+!
+! * This module MUST be includable by CAM and CLM * (be careful with uses)
+!
+!
+! This routine has a bunch of "qtiny" - which could be standardized.
+!
+! Original Code Author: David Noone <dcn@colorado.edu> - March 2003
+!
+! Module added to CESM's csm_share by:  Jesse Nusbaumer <nusbaume@colorado.edu> - March 2011
+!
+!-----------------------------------------------------------------------
+#undef NOFRAC          /* all fractionation factors = 1 */
+#undef NOKIN           /* all kinetic effects off */
+!-----------------------------------------------------------------------
+
+  use shr_kind_mod,  only: r8 => shr_kind_r8
+  use shr_const_mod, only: SHR_CONST_TKTRIP
+!                           SHR_CONST_RSTD_H2ODEV, &
+!                           SHR_CONST_VSMOW_16O, &
+!                           SHR_CONST_VSMOW_18O, &
+!                           SHR_CONST_VSMOW_D , &
+!                           SHR_CONST_VSMOW_H
+
+  implicit none
+  private
+
+! Public interfaces
+
+  !Initialization routines:
+
+  public :: wiso_init            ! initilize water isotopes/tracers.
+  public :: wiso_get_ispec       ! lookup a species index by name
+
+  !Fractionation routines:
+
+  public :: wiso_alpl            ! look-up liquid/vapor equil. fractn.
+  public :: wiso_alpi            ! look-up ice/vapor equil. fractn.
+  public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
+  public :: wiso_kmolv10         ! kmol (as above) from 10 meter wind (M&J)
+  public :: wiso_akel            ! kinetic fractionation at liq. evaporation
+  public :: wiso_akci            ! kinetic fractnation at ice condensation
+
+  !Calculation routines:
+
+  public :: wiso_get_roce        ! retrive ocean isotope ratio.
+  public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
+  public :: wiso_ssatf           ! supersaturation function
+  public :: wiso_heff            ! effective humidity function
+
+  !Data checking routines:
+
+  public :: wiso_get_rstd        !retrive standard isotope ratio
+  public :: wiso_get_fisub       !retrive isotope subsitutions
+                                 !aka number of iso. atoms per molec.
+  public :: wiso_ratio           !calculate mass ratio of isotope .
+  public :: wiso_delta           !calculate the delta value for isotopes.
+
+
+!configuration pointers/indices   (Added from water_tracers - JN)
+!  integer, public :: iwspec(pcnst+pnats)     ! flag for water (isotope) species
+!  integer, public :: ixwti, ixwtx     ! lowest and highest index to search
+
+! Species indicies - public so thay can be seen by water_tracers
+  integer, parameter, public  :: ispundef = 0    ! Undefined
+  integer, parameter, public  :: isph2o   = 1    ! H2O    ! "regular" water
+  integer, parameter, public  :: isph216o = 2    ! H216O  ! H216O, nearly the same as "regular" water
+  integer, parameter, public  :: isphdo   = 3    ! HDO
+  integer, parameter, public  :: isph218o = 4    ! H218O
+
+! Module parameters
+  integer , parameter, public :: pwtspec = 4    ! number of water species (h2o,hdo,h218o,h216o)
+
+! Tunable prameters for fractionation scheme
+  real(r8), parameter :: dkfac    = 0.58_r8           ! diffusive evap. kinetic power law
+!  real(r8), parameter :: tkini    = SHR_CONST_TKTRIP  ! min temp. for kinetic effects as ice appears
+!  real(r8), parameter :: tkini    = 258.15_r8         !From Bony et. al., 2008
+  real(r8), parameter :: tkini    = 253.15_r8         !From Jouzel and Merlivat, 1984
+
+  real(r8), parameter :: recrit   = 1.0_r8            ! critical raynolds number for kmol
+
+  real(r8), parameter :: fsata    = 1.000_r8          ! supersaturation peramater s = a +
+!bTdegC (Hoffman)
+!  real(r8), parameter :: fsatb    = -0.003_r8         ! supersaturation parameter s = a +
+  real(r8), parameter :: fsatb    = -0.002_r8         !tuned to match Antarctic d-excess in precip. - JN
+!bTdegC (Hoffman)
+  real(r8), parameter :: ssatmx   = 2.00_r8           ! maximum supersaturation
+  real(r8), parameter :: fkhum    = 0.25_r8           ! effective humidity factor
+  real(r8), parameter :: tzero    = SHR_CONST_TKTRIP  ! supercooled water in stratiform
+
+  character(len=8), dimension(pwtspec), parameter, public :: & ! species names
+      spnam  = (/ 'H2O     ', 'H216O   ', 'HD16O   ', 'H218O   ' /)
+
+! Private isotopic constants
+!
+
+!
+! Physical constants for isotopic molecules
+!
+  real(r8), dimension(pwtspec), parameter :: &  ! isotopic subs.
+      fisub = (/ 1._r8, 1._r8, 2._r8, 1._r8 /)
+
+  ! TBD: Ideally this should be controlled by something like a namelist parameter,
+  ! but it needs to be something that can be made consistent between models.
+  real(r8), dimension(pwtspec), parameter :: &  ! diffusivity ratio (note D/H, not HDO/H2O)
+!     difrm = (/ 1._r8, 1._r8, 0.9836504_r8, 0.9686999_r8 /)   ! kinetic theory
+!      difrm = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)                 ! no kinetic fractination
+!      difrm = (/ 1._r8, 1._r8, 0.9836504_r8, 0.9686999_r8 /)   ! this with expk
+!      difrm = (/ 1._r8, 1._r8, 0.9755_r8, 0.9723_r8 /)         ! Merlivat 1978 (tuned for isoCAM3)
+       difrm = (/ 1._r8, 1._r8, 0.9757_r8, 0.9727_r8 /)         ! Merlivat 1978 (direct from paper)
+!      difrm = (/ 1._r8, 1._r8, 0.9839_r8, 0.9691_r8 /)         ! Cappa etal 2003
+
+! Prescribed isotopic ratios (largely arbitrary and tunable)
+  real(r8), dimension(pwtspec), parameter :: &  ! model standard isotope ratio
+!suggested by D. Noone:
+       rstd  = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)                    ! best numerics
+!      rstd  = (/ 1._r8, 0.5_r8, 0.25_r8, 0.2_r8, 0.1_r8 /)         ! test numerics
+!     rstd  = (/ 1._r8, 0.9976_r8, 155.76e-6_r8, 2005.20e-6_r8 /)   ! natural abundance
+!     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_VSMOW_16O, SHR_CONST_VSMOW_D, SHR_CONST_VSMOW_18O /)   ! natural abundance
+!     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV /)   !all 1.0
+
+! Isotope enrichment at ocean surface (better to be computed or read from file)
+  real(r8), dimension(pwtspec), parameter :: &  ! mean ocean surface enrichent
+!      boce  = (/ 1._r8, 1._r8, 1.004_r8, 1.0005_r8 /)
+!      boce  = (/ 1._r8, 1._r8, 1.0128_r8, 1.0016_r8, 1.0008_r8, 1.00671_r8 /)  ! LGM
+      boce  = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)
+
+! Ocean surface kinetic fractionation parameters for M&J method:
+! TBD: Check to make sure that the entries for h216o are correct.
+  real(r8), parameter, dimension(pwtspec) :: &  ! surface kinetic exchange
+      aksmc = (/ 0._r8, 0._r8, 0.00528_r8,   0.006_r8    /), &
+      akrfa = (/ 0._r8, 0._r8, 0.2508e-3_r8, 0.285e-3_r8 /), &
+      akrfb = (/ 0._r8, 0._r8, 0.7216e-3_r8, 0.82e-3_r8  /)
+
+! Coefficients for fractionation
+! TBD: Check to make sure that the entries for h216o are correct.
+!From Majoube, 1971a:
+!  real(r8), parameter, dimension(pwtspec) :: &  ! liquid/vapour
+!      alpal = (/ 0._r8, 0._r8, 24.844e+3_r8, 1.137e+3_r8   /) , &
+!      alpbl = (/ 0._r8, 0._r8, -76.248_r8,   -0.4156_r8    /) , &
+!      alpcl = (/ 0._r8, 0._r8, 52.612e-3_r8, -2.0667e-3_r8 /)
+
+!From Horita and Wesolowski, 1994:
+  real(r8), parameter, dimension(pwtspec) :: &  ! liquid/vapour
+      alpal = (/ 0._r8, 0._r8, 1158.8e-12_r8, 0.35041e+6_r8 /), &
+      alpbl = (/ 0._r8, 0._r8, -1620.1e-9_r8, -1.6664e+3_r8 /), &
+      alpcl = (/ 0._r8, 0._r8, 794.84e-6_r8, 6.7123_r8      /), &
+      alpdl = (/ 0._r8, 0._r8, -161.04e-3_r8, -7.685e-3_r8  /), &
+      alpel = (/ 0._r8, 0._r8, 2.9992e+6_r8, 0._r8 /)
+
+!isoCAM3 values:
+!  real(r8), parameter, dimension(pwtspec) :: &  ! ice/vapour
+!      alpai = (/ 0._r8, 0._r8, 16288._r8,   0._r8         /), &
+!      alpbi = (/ 0._r8, 0._r8, 0._r8,       11.839_r8     /), &
+!      alpci = (/ 0._r8, 0._r8, -9.34e-2_r8, -28.224e-3_r8 /)
+
+!From Merlivat & Nief,1967 for HDO, and Majoube, 1971b for H218O:
+ real(r8), parameter, dimension(pwtspec) :: &  ! ice/vapour
+      alpai = (/ 0._r8, 0._r8, 16289._r8,   0._r8         /), &
+      alpbi = (/ 0._r8, 0._r8, 0._r8,       11.839_r8     /), &
+      alpci = (/ 0._r8, 0._r8, -9.45e-2_r8, -28.224e-3_r8 /)
+
+contains
+
+!-----------------------
+!Initialization routines:
+!-----------------------
+
+!=======================================================================
+  subroutine wiso_init
+!-----------------------------------------------------------------------
+! Purpose: Initialize module internal data arrays
+! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:26 MDT 2003
+!-----------------------------------------------------------------------
+    write(6,*) 'WISO_INIT: Initializing water isotopes.'
+    return
+  end subroutine wiso_init
+
+!----------------------
+!Fractionation routines:
+!----------------------
+
+!=======================================================================
+  subroutine wiso_kmol(isp,rbot,zbot,ustar,alpkn)
+!-----------------------------------------------------------------------
+!
+! Purpose: compute kinetic modifier for drag coefficient (Merlivat & Jouzel)
+!
+! Method:
+!   Code solves Brutsaert equations for theturbulent layer using GCM computed
+!   quantities.  Operates on a vector of points.
+!
+! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 14:05:38 MDT 2003
+!
+!-----------------------------------------------------------------------
+    use shr_kind_mod,  only: r8 => shr_kind_r8
+    use shr_const_mod, only: shr_const_g, shr_const_karman
+
+    implicit none
+
+    real(r8), parameter :: difair = 2.36e-5_r8          ! molecular diffusivity of air
+    real(r8), parameter :: muair  = 1.7e-5_r8           ! dynamic viscosity of air
+                                                     ! about 17 degC, 1.73 at STP (Salby)
+    real(r8), parameter :: gravit = shr_const_g      ! gravity
+    real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
+
+!---------------------------- Arguments --------------------------------
+    integer , intent(in)  :: isp   ! species flag
+    real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
+    real(r8), intent(in)  :: zbot  ! height of lowest level (m)
+    real(r8), intent(in)  :: ustar ! Friction velocity (m/s)
+!
+    real(r8), intent(out) :: alpkn ! kinetic fractionation factor (1-kmol)
+
+!------------------------- Local Variables -----------------------------
+    real(r8) z0                 ! roughness length (constant in cam 9.5e-5)
+    real(r8) reno               ! surface reynolds number
+    real(r8) tmr                ! ratio of turbulen to molecular resistance
+    real(r8) enn                ! diffusive power
+    real(r8) sc                 ! Schmidt number (Prandtl number)
+    real(r8) vmu                ! kinematic viscocity of air
+    real(r8) difn               ! ratio of difusivities to the power of n
+    real(r8) difrmj             ! isotopic diffusion with substitutions
+
+    real(r8) kmol               ! Merlivals k_mol
+!-----------------------------------------------------------------------
+!
+!!    difrmj = difrm(isp)/fisub(isp)
+    difrmj = difrm(isp)
+!
+      z0 = (ustar**2._r8)/(81.1_r8*gravit)  ! Charnock's equation
+      vmu = muair / rbot             ! kinematic viscosity
+      Sc  = vmu/difair
+      reno = ustar*z0 / vmu       ! reynolds number
+!
+      if (reno < recrit) then        ! Smooth (Re < 0.13)
+         enn = 2._r8/3._r8
+         tmr  = ( (1._r8/karman)*log(ustar*zbot / (30._r8 * vmu)) ) / (13.6_r8 * Sc**(2._r8/3._r8))
+      else                           ! Rough  (Re > 2)
+         enn = 1._r8/2._r8
+         tmr  = ( (1._r8/karman)*log(zbot/z0) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
+      end if
+
+      difn = (1._r8/difrmj)**enn        ! use D/Di, not Di/D
+      kmol = (difn - 1._r8) / (difn + tmr)
+
+      alpkn = 1._r8 - kmol
+
+#ifdef NOKIN
+!      alpkn = 1._r8
+#endif
+!
+    return
+  end subroutine wiso_kmol
+
+!=======================================================================
+  subroutine wiso_kmolv10(isp,ustar,alpkn)
+!-----------------------------------------------------------------------
+!
+! Purpose: compute kinetic modifier for drag coefficient (Merlivat &
+! Jouzel, 1979)
+!
+! Method:
+!    Uses everyones favorite empirical relation to 10 meter windspeed
+!
+! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 14:05:38 MDT 2003
+!
+! Modified U(z=10 m) calculation: Jesse Nusbaumer <nusbaume@colorado.edu> - Sept.
+! 2011
+!
+!-----------------------------------------------------------------------
+    use shr_kind_mod, only: r8 => shr_kind_r8
+    use shr_const_mod, only: shr_const_g, shr_const_karman
+
+    implicit none
+
+    real(r8), parameter :: gravit = shr_const_g      ! gravity
+    real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
+
+!---------------------------- Arguments --------------------------------
+    integer , intent(in)  :: isp          ! species flag
+    real(r8), intent(in)  :: ustar        !friction velocity
+!
+    real(r8), intent(out) :: alpkn ! kinetic fractionation fatcor
+
+!------------------------- Local Variables -----------------------------
+    real(r8) z0                 ! roughness length
+    real(r8) v10                ! 10 meter winds
+    real(r8) kmol               ! Merlivat's K_mol
+!-----------------------------------------------------------------------
+!
+    z0 = (ustar**2._r8)/(81.1_r8*gravit)      ! Charnock's equation
+!
+    v10 = ustar*log(10._r8/z0)/karman  !calculate U(z=10 m) wind speed.
+!
+! Compute the kinetic fractionation:
+!
+      if (v10 < 7.0_r8) then              ! smooth regime
+         kmol = aksmc(isp)
+      else                             ! rough regime
+         kmol = akrfa(isp)*v10 + akrfb(isp)
+      end if
+!
+      alpkn = 1._r8 - kmol
+!
+!#ifdef NOKIN
+!      alpkn = 1.0_r8
+!#endif
+!
+    return
+  end subroutine wiso_kmolv10
+
+!=======================================================================
+  function wiso_alpl(isp,tk)
+!-----------------------------------------------------------------------
+! Purpose: return liquid/vapour fractionation from look-up tables
+! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 10:59:13 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)        :: isp  ! species indes
+    real(r8), intent(in)        :: tk    ! temperature (k)
+    real(r8) :: wiso_alpl               ! return fractionation
+!-----------------------------------------------------------------------
+!
+    if (isp == isph2o) then
+      wiso_alpl = 1._r8
+      return
+    end if
+!Majoube, 1971:
+!    wiso_alpl = exp(alpal(isp)/tk**2 + alpbl(isp)/tk + alpcl(isp))
+
+!Horita and Wesolowski, 1994:
+    if(isp == isphdo) then !HDO has different formulation:
+      wiso_alpl = exp(alpal(isp)*tk**3 + alpbl(isp)*tk**2 + alpcl(isp)*tk + alpdl(isp) + alpel(isp)/tk**3)
+    else
+      wiso_alpl = exp(alpal(isp)/tk**3 + alpbl(isp)/tk**2 + alpcl(isp)/tk + alpdl(isp))
+    end if
+
+#ifdef NOFRAC
+    wiso_alpl = 1._r8
+#endif
+!
+    return
+  end function wiso_alpl
+
+!=======================================================================
+  function wiso_alpi(isp,tk)
+!-----------------------------------------------------------------------
+! Purpose: return ice/vapour fractionation from loop-up tables
+! Author:  David Noone <dcn@caltech.edu> - Tue Jul  1 12:02:24 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)        :: isp  ! species indes
+    real(r8), intent(in)        :: tk   ! temperature (k)
+    real(r8) :: wiso_alpi               ! return fractionation
+!-----------------------------------------------------------------------
+    if (isp == isph2o) then
+      wiso_alpi = 1._r8
+      return
+    end if
+
+    wiso_alpi = exp(alpai(isp)/tk**2 + alpbi(isp)/tk + alpci(isp))
+
+#ifdef NOFRAC
+    wiso_alpi = 1._r8
+#endif
+!
+    return
+end function wiso_alpi
+
+!=======================================================================
+function wiso_akel(isp,tk,hum0,alpeq)
+!-----------------------------------------------------------------------
+! Purpose: return modified fractination for kinetic effects during
+!          liquid evaporation into unsaturated air.
+! Author:  David Noone <dcn@caltech.edu> - Tue Jul  1 12:02:24 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)        :: isp   ! species indes
+    real(r8), intent(in)        :: tk    ! Temperature (K)
+    real(r8), intent(in)        :: hum0  ! initial humidity ()
+    real(r8), intent(in)        :: alpeq ! equilibrium fractionation factor
+    real(r8) :: wiso_akel                ! return effective fractionation
+    real(r8) :: h0                       ! humidity
+    real(r8) :: heff                     ! effective humidity
+    real(r8) :: difrmj                   ! diffusivity for iso. sub. hum.
+    real(r8) :: dondi                    ! (D / Di)^fdif, (rather than Di/D)
+!-----------------------------------------------------------------------
+!!    if (tk > tkinl) then              ! also do it for supercooled water
+      h0 = min(1.0_r8,hum0)
+!!      difrmj = difrm(isp)/fisub(isp)
+      difrmj = difrm(isp)
+      heff = wiso_heff(h0)
+      dondi = (1/difrmj)**dkfac
+      wiso_akel = alpeq*heff / (alpeq*dondi*(heff-1._r8) + 1._r8)
+!!    else
+!!      wiso_akel = alpeq
+!!    end if
+!
+! Modify for non-standard isotope
+!
+!!    wiso_akel = wiso_akel**expk(isp)
+
+#ifdef NOKIN
+    wiso_akel = alpeq
+#endif
+
+    return
+end function wiso_akel
+
+!=======================================================================
+  function wiso_akci(isp,tk,alpeq)
+!-----------------------------------------------------------------------
+! Purpose: return modified fractination for kinetic effects during
+!          condensation to ice.
+!          Make use of supersaturation function.
+! Author:  David Noone <dcn@caltech.edu> - Tue Jul  1 12:02:24 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)        :: isp   ! species indes
+    real(r8), intent(in)        :: tk    ! temperature (k)
+    real(r8), intent(in)        :: alpeq ! equilibrium fractionation factor
+    real(r8) :: wiso_akci               ! return effective fractionation
+    real(r8) :: sat1                    ! super sturation
+    real(r8) :: difrmj                  ! isotopic diffusion for subs. molec.
+    real(r8) :: dondi                   ! D / Di, (rather than Di/D)
+!-----------------------------------------------------------------------
+!
+    if (tk < tkini) then                ! anytime below freezing
+      sat1 = max(1._r8, wiso_ssatf(tk))
+!!      difrmj = difrm(isp)/fisub(isp)
+      difrmj = difrm(isp)
+      dondi = 1._r8/difrmj
+      wiso_akci = alpeq*sat1 / (alpeq*dondi*(sat1-1._r8) + 1._r8)
+    else
+      wiso_akci = alpeq
+    end if
+!
+! Modify for non-standard isotope
+!
+!!    wiso_akci = wiso_akci**expk(isp)
+
+#ifdef NOKIN
+    wiso_akci = alpeq
+#endif
+!
+    return
+end function wiso_akci
+
+!--------------------
+!Calculation routines
+!--------------------
+
+!=======================================================================
+  function wiso_get_roce(isp)
+!-----------------------------------------------------------------------
+! Purpose: Retrieve internal Roce variable, based on species index
+! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:04 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)  :: isp          ! species index
+    real(r8) :: wiso_get_roce             ! return isotope ratio
+!-----------------------------------------------------------------------
+    wiso_get_roce = boce(isp)*rstd(isp)
+    return
+  end function wiso_get_roce
+
+!=======================================================================
+
+!=======================================================================
+
+ subroutine wiso_flxoce( iso  ,rbot   ,zbot   ,wtbot   , &
+                         ts     , rocn, ustar  ,re , &
+                        ssq, qflx, qbot, qe )
+
+!-----------------------------------------------------------------------
+!
+! Purpose: compute water tracer exchange from ocean
+!
+! Method:
+!   Used diagnostics output from (./dom/)flxoce to ensure
+!   quantities are exactly equal for constituent number 1.
+!   Isotopic fractionation (equilibrium and kinetci) is applied,
+!   when needed.
+!
+
+!     E = fac (q - qs(ts))
+!
+!   where fac is some exchange efficiency and qs is the saturation
+!   vapour mixing rati at the surface temperature. These are needed
+!   from calling routine to solve isotopic equivilent.
+!
+!     Ei = fac (1-kmol) (qi - qs(ts)*Rocn/alpha)
+!
+!   To compute the kinetic drag modifneed also
+!
+! Author:
+!   David Noone <dcn@caltech.edu> - Mon Jun 30 10:24:49 MDT 2003
+!
+!   Ported to CAM5, and added Schmidt, 1999 scheme - Jesse Nusbaumer <nusbaume@colorado.edu> - April, 2012
+!
+!-----------------------------------------------------------------------
+!  use shr_kind_mod, only: r8 => shr_kind_r8
+!  use water_tracers, only: trace_water, wtrc_is_vap, iwspec, ixwti, ixwtx
+!  use water_isotopes, only: wisotope, wiso_kmol, wiso_alpl,wiso_get_roce, &
+!                              wiso_alpi
+
+  implicit none
+
+!---------------------------- Arguments --------------------------------
+!
+   integer , intent(in)  :: iso    ! isotope value (1=16O,2=D,3=18O)
+  real(r8), intent(in)  :: rbot    ! density of lowest layer (kg/m3)
+  real(r8), intent(in)  :: zbot    ! height of lowest level (m)
+  real(r8), intent(in)  :: wtbot   ! constituents at lowest
+  real(r8), intent(in)  :: qbot    ! bulk water (q) at lowest
+  real(r8), intent(in)  :: qe      ! bulk evaporative flux (evp)
+
+  real(r8), intent(in)  :: ts    ! (sea) surface temperature K
+  real(r8), intent(in)  :: rocn  ! (sea) surface temperature iso ratio/Rstd
+  real(r8), intent(in)  :: ustar ! friction velocity (m/s)
+  real(r8), intent(in)  :: re    ! Reynolds number ?
+  real(r8), intent(in)  :: ssq   ! s.hum. saturation at Ts
+!
+  real(r8), intent(out) :: qflx ! constituentflux (kg/kg/s)
+!
+!------------------------- Local Variables -----------------------------
+  real(r8) alpkn                        ! kinetic fractionation efficiency (m)
+  real(r8) tau                          ! stress
+  real(r8) delq                         ! spec. hum. difference
+  real(r8) qstar                        ! spec. hum,. mixing scale
+  real(r8) Roce                         ! water tracer ratio of ocean surface
+  real(r8) alpha                        ! fractionation factor
+  real(r8) R_std                        ! tracer ratio in evaporation
+!-----------------------------------------------------------------------
+!
+!--------------------------
+!calculate isotopic factors
+!--------------------------
+!
+  alpha = wiso_alpl(iso,ts)                            !get equilibrium frac. factor
+ ! call wiso_kmolv10(iso,ustar,alpkn)                   !get kinetic frac. factor
+  call wiso_kmol(iso,rbot,zbot,ustar,alpkn)            !Advanced kinetic frac. routine
+
+  if(rocn .eq. 0._r8) then                             !no ocean model data:
+    Roce = wiso_get_roce(iso)                          !set to default value
+  else                                                 !isotopic ocean model present:
+    R_std = wiso_get_rstd(iso)                         !pull ratio from ocean data
+    Roce = R_std*rocn
+  end if                                               !rocn value
+!
+!-----------------------------------------------
+!David Noone (Merlivat and Jouzel, 1979) version
+!-----------------------------------------------
+!
+! Compute the vapour deficit then, get the fluxes
+!
+        delq  = wtbot - ssq*Roce/alpha
+
+        qstar = re*delq
+        tau   = rbot * ustar * ustar
+
+        qflx = tau*alpkn*qstar/ustar
+!
+!---------------------
+!Schmidt, 1999 version
+!---------------------
+!
+!         rh = qbot/ssq                                         !calculate relative humidity
+!
+!If RH is 100%, then assume no evaporation occurs (although isotopic equilibration does, which needs to be coded in)
+!
+!         if(rh /= 1) then
+!           Rate = alpkn*(Roce/alpha - (rh*wtbot/qbot))/(1-rh)  !calculate ratio in flux
+!         else
+!           Rate = 0                                            !Assume no evaporation occurs if RH is 100%
+!         end if
+!
+!         qflx = Rate*qe                                        !convert to specific humidity (qi)
+
+  return
+end subroutine wiso_flxoce
+
+!=======================================================================
+ function wiso_heff(h0)
+!-----------------------------------------------------------------------
+! Purpose: Compute effective humidity (Jouzel type thing)
+! Author: David Noone <dcn@caltech.edu> - Fri Oct 24 12:06:55 PDT 2003
+!-----------------------------------------------------------------------
+    real(r8), intent(in)  :: h0       ! initial humidity
+    real(r8) :: wiso_heff             ! return humidity (subsaturation)
+!-----------------------------------------------------------------------
+    wiso_heff = min(1.0_r8, fkhum*h0 + 1.0_r8-fkhum)
+    return
+end function wiso_heff
+
+!=======================================================================
+function wiso_ssatf(tk)
+!-----------------------------------------------------------------------
+! Purpose: Compute supersaturation based on temperature parameterization.
+! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:14 MDT 2003
+!-----------------------------------------------------------------------
+    real(r8), intent(in)  :: tk           ! temperature
+    real(r8) :: wiso_ssatf            ! return supersaturation
+!-----------------------------------------------------------------------
+#ifdef OLDWAY
+    wiso_ssatf = max(1.0_r8, fsata + fsatb*(tk-tzero))
+#else
+    wiso_ssatf = fsata + fsatb*(tk-tzero)
+!!    wiso_ssatf = max(wiso_ssatf, fsata)
+    wiso_ssatf = max(wiso_ssatf, 1.0_r8)
+    wiso_ssatf = min(wiso_ssatf, ssatmx)
+#endif
+    return
+end function wiso_ssatf
+
+!----------------------
+!Data checking routines:
+!----------------------
+
+!=======================================================================
+  function wiso_get_rstd(isp)
+!-----------------------------------------------------------------------
+! Purpose: Retrieve internal Rstd variable, based on species index
+! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:14 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)  :: isp          ! species index
+    real(r8) :: wiso_get_rstd             ! return isotope ratio
+!-----------------------------------------------------------------------
+    wiso_get_rstd = rstd(isp)
+    return
+  end function wiso_get_rstd
+
+!=======================================================================
+  function wiso_get_fisub(isp)
+!-----------------------------------------------------------------------
+! Purpose: Retrieve internal fisub variable, based on species index
+! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:28:52 MDT 2003
+!-----------------------------------------------------------------------
+    integer , intent(in)  :: isp         ! species index
+    real(r8) :: wiso_get_fisub           ! return number of substitutions
+!-----------------------------------------------------------------------
+    wiso_get_fisub = fisub(isp)
+    return
+  end function wiso_get_fisub
+
+!=======================================================================
+  function wiso_get_ispec(name)
+!-----------------------------------------------------------------------
+! Purpose: Retrieve speciies index, based on species name
+! Author: Chuck Bardeen
+!-----------------------------------------------------------------------
+    character(len=*),  intent(in)  :: name  ! species name
+    integer  :: wiso_get_ispec              ! return species index
+!-----------------------------------------------------------------------
+    do wiso_get_ispec = 1, pwtspec
+      if (name == spnam(wiso_get_ispec)) then
+        return
+      end if
+    end do
+    wiso_get_ispec = ispundef
+    return
+  end function wiso_get_ispec
+
+!=======================================================================
+  function wiso_ratio(isp,qiso,qtot)
+!-----------------------------------------------------------------------
+! Purpose: Compute isotopic ratio from masses, with numerical checks
+! Author David Noone <dcn@caltech.edu> - Tue Jul  1 08:32:45 MDT 2003
+!-----------------------------------------------------------------------
+    integer, intent(in)  :: isp         ! species index
+    real(r8),intent(in)  :: qiso        ! isotopic mass
+    real(r8),intent(in)  :: qtot        ! isotopic mass
+    real(r8) :: wiso_ratio              ! return value
+!-----------------------------------------------------------------------
+! TBD: This qtiny is different than found in the equivalent routine in
+! water _tracers. Also, this value is larger than the smallest support
+! mixing ratios, and probably should be made smaller so as not to
+! produce incorrect ratios for small values.
+    real(r8) :: qtiny = 1.e-16_r8
+!-----------------------------------------------------------------------
+    if (qtot > 0._r8) then
+      wiso_ratio = qiso/(qtot+qtiny)
+    else
+      wiso_ratio = qiso/(qtot-qtiny)
+    end if
+!!    wiso_ratio = espmw(isp)*wiso_ratio/fisum(isp)      ! correct!
+  end function wiso_ratio
+
+!=======================================================================
+  function wiso_delta(isp,qiso,qtot)
+!-----------------------------------------------------------------------
+! Purpose: Compute isotopic delta value from masses
+! Author David Noone <dcn@caltech.edu> - Tue Jul  1 08:32:45 MDT 2003
+!-----------------------------------------------------------------------
+    integer, intent(in)  :: isp         ! species index
+    real(r8),intent(in)  :: qiso        ! isotopic mass
+    real(r8),intent(in)  :: qtot        ! isotopic mass
+    real(r8) :: wiso_delta              ! return value
+!-----------------------------------------------------------------------
+    wiso_delta = 1000._r8 * (wiso_ratio(isp,qiso,qtot) / Rstd(isp) - 1._r8)
+    return
+  end function wiso_delta
+
+!=========================================================================
+end module shr_wiso_mod

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -1,201 +1,62 @@
 module shr_wiso_mod
 !-----------------------------------------------------------------------
 !
-! Provides the functions and constants needed to calculate the isotopc flux from
-! water on the ocean surface into the atmosphere.
+! This module provides the functions and constants needed to calculate
+! the isotopic fractionation of water during phase changes across all
+! modeled components of the Earth system.
 !
-! All interface routine are identified by wiso_*, etc.
-!
-! This code works over species indices, rather than the constituent indices
-! used in the water_tracers module. As such, MAKE SURE you call these
-! routines with species indicies! The tracer variable names do not need to
-! match the species names, which are privided just for diagnostic output.
-!
-! * This module MUST be includable by CAM and CLM * (be careful with uses)
-!
-!
-! This routine has a bunch of "qtiny" - which could be standardized.
-!
-! Original Code Author: David Noone <dcn@colorado.edu> - March 2003
-!
-! Module added to CESM's csm_share by:  Jesse Nusbaumer <nusbaume@colorado.edu> - March 2011
+! This module also provides a specialized routine for calculating the isotopic
+! flux during ocean/atmosphere exchanges, which is not currently owned by
+! a specific component model (at least in CESM).
 !
 !-----------------------------------------------------------------------
 
-  use shr_kind_mod,  only: r8 => shr_kind_r8
-  use shr_const_mod, only: SHR_CONST_TKTRIP
+  use shr_kind_mod,     only: r8 => shr_kind_r8
+  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
+  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
+  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
+  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
 
   implicit none
   private
 
+!++++++++++++++++++
 ! Public interfaces
+!++++++++++++++++++
 
-  !Fractionation routines:
+  ! Generic fractionation routines (used by most/all component models):
 
   public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
   public :: wiso_ice_vap_equil_frac_factor ! Function for calculating ice/vapor equilibrium fractionation factor
-  public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
 
-  !Calculation routines:
+  !Atmosphere-Ocean flux calculation routines (used only by the atm/ocn flux modules):
 
   public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
-  public :: wiso_ssatf           ! supersaturation function
+  public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
 
-  !Data checking routines:
-
-  public :: wiso_get_rstd        !retrive standard isotope ratio
-  public :: wiso_get_ispec       !lookup a species index by name
-  public :: wiso_get_fisub       !retrive isotope subsitutions
-                                 !aka number of iso. atoms per molec.
-  public :: wiso_ratio           !calculate mass ratio of isotope .
-  public :: wiso_delta           !calculate the delta value for isotopes.
-
-! Species indicies - public so thay can be seen by water_tracers
-!NOTE: THESE SHOULD COME FROM 'shr_wtracer_mod.F90' once the share PR has been merged!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  FIX THIS BEFORE OPENING PR!
-  integer, parameter :: WATER_SPECIES_TYPE_BULK = 0  ! This one is special: total/bulk water rather than a species
-  integer, parameter :: WATER_SPECIES_TYPE_H218O = 1
-  integer, parameter :: WATER_SPECIES_TYPE_H217O = 2
-  integer, parameter :: WATER_SPECIES_TYPE_HDO = 3
-
-  !DELETE WHEN THESE PARAMETERS NO LONGER EXIST IN THIS FILE!!!!
-  integer, parameter, public  :: ispundef = 0    ! Undefined
-  integer, parameter, public  :: isph2o   = 1    ! H2O    ! "regular" water
-  integer, parameter, public  :: isph216o = 2    ! H216O  ! H216O, nearly the same as "regular" water
-  integer, parameter, public  :: isphdo   = 3    ! HDO
-  integer, parameter, public  :: isph218o = 4    ! H218O
-
-! Module parameters
-  integer , parameter, public :: pwtspec = 4    ! number of water species (h2o,hdo,h218o,h216o)
-
-! Tunable prameters for fractionation scheme
-  real(r8), parameter :: dkfac    = 0.58_r8           ! diffusive evap. kinetic power law
-!  real(r8), parameter :: tkini    = SHR_CONST_TKTRIP  ! min temp. for kinetic effects as ice appears
-!  real(r8), parameter :: tkini    = 258.15_r8         !From Bony et. al., 2008
-  real(r8), parameter :: tkini    = 253.15_r8         !From Jouzel and Merlivat, 1984
-
-  real(r8), parameter :: recrit   = 1.0_r8            ! critical raynolds number for kmol
-
-  real(r8), parameter :: fsata    = 1.000_r8          ! supersaturation peramater s = a +
-!bTdegC (Hoffman)
-!  real(r8), parameter :: fsatb    = -0.003_r8         ! supersaturation parameter s = a +
-  real(r8), parameter :: fsatb    = -0.002_r8         !tuned to match Antarctic d-excess in precip. - JN
-!bTdegC (Hoffman)
-  real(r8), parameter :: ssatmx   = 2.00_r8           ! maximum supersaturation
-  real(r8), parameter :: fkhum    = 0.25_r8           ! effective humidity factor
-  real(r8), parameter :: tzero    = SHR_CONST_TKTRIP  ! supercooled water in stratiform
-
-  character(len=8), dimension(pwtspec), parameter, public :: & ! species names
-      spnam  = (/ 'H2O     ', 'H216O   ', 'HD16O   ', 'H218O   ' /)
-
-! Private isotopic constants
-!
-
-!
+!++++++++++++++++++++++++++++++++++++++++++
 ! Physical constants for isotopic molecules
-!
-  real(r8), dimension(pwtspec), parameter :: &  ! isotopic subs.
-      fisub = (/ 1._r8, 1._r8, 2._r8, 1._r8 /)
+!++++++++++++++++++++++++++++++++++++++++++
 
-  ! TBD: Ideally this should be controlled by something like a namelist parameter,
-  ! but it needs to be something that can be made consistent between models.
-  real(r8), dimension(pwtspec), parameter :: &  ! diffusivity ratio (note D/H, not HDO/H2O)
-!     difrm = (/ 1._r8, 1._r8, 0.9836504_r8, 0.9686999_r8 /)   ! kinetic theory
-!      difrm = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)                 ! no kinetic fractination
-!      difrm = (/ 1._r8, 1._r8, 0.9836504_r8, 0.9686999_r8 /)   ! this with expk
-!      difrm = (/ 1._r8, 1._r8, 0.9755_r8, 0.9723_r8 /)         ! Merlivat 1978 (tuned for isoCAM3)
-       difrm = (/ 1._r8, 1._r8, 0.9757_r8, 0.9727_r8 /)         ! Merlivat 1978 (direct from paper)
-!      difrm = (/ 1._r8, 1._r8, 0.9839_r8, 0.9691_r8 /)         ! Cappa etal 2003
+! Diffusivity ratios for HDO and H218O relative to H216O:
 
-! Prescribed isotopic ratios (largely arbitrary and tunable)
-  real(r8), dimension(pwtspec), parameter :: &  ! model standard isotope ratio
-!suggested by D. Noone:
-       rstd  = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)                    ! best numerics
-!      rstd  = (/ 1._r8, 0.5_r8, 0.25_r8, 0.2_r8, 0.1_r8 /)         ! test numerics
-!     rstd  = (/ 1._r8, 0.9976_r8, 155.76e-6_r8, 2005.20e-6_r8 /)   ! natural abundance
-!     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_VSMOW_16O, SHR_CONST_VSMOW_D, SHR_CONST_VSMOW_18O /)   ! natural abundance
-!     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV /)   !all 1.0
+! Values from:
 
-! Ocean surface kinetic fractionation parameters for M&J method:
-! TBD: Check to make sure that the entries for h216o are correct.
-  real(r8), parameter, dimension(pwtspec) :: &  ! surface kinetic exchange
-      aksmc = (/ 0._r8, 0._r8, 0.00528_r8,   0.006_r8    /), &
-      akrfa = (/ 0._r8, 0._r8, 0.2508e-3_r8, 0.285e-3_r8 /), &
-      akrfb = (/ 0._r8, 0._r8, 0.7216e-3_r8, 0.82e-3_r8  /)
+! Merlivat, L.,
+! Molecular diffusivities of H216O, HD16O, and H218O in gases
+! Journal of Chemical Physics, 69, 2864-2871, September 1978
+! DOI: 10.1063/1.436884
+
+real(r8), parameter :: DIFF_RATIO_HDO   = 0.9757_r8
+real(r8), parameter :: DIFF_RATIO_H218O = 0.9727_r8
+
+!=======================================================================
 
 contains
 
 !----------------------
 !Fractionation routines:
 !----------------------
-
-!=======================================================================
-  subroutine wiso_kmol(isp,rbot,zbot,ustar,alpkn)
-!-----------------------------------------------------------------------
-!
-! Purpose: compute kinetic modifier for drag coefficient (Merlivat & Jouzel)
-!
-! Method:
-!   Code solves Brutsaert equations for theturbulent layer using GCM computed
-!   quantities.  Operates on a vector of points.
-!
-! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 14:05:38 MDT 2003
-!
-!-----------------------------------------------------------------------
-    use shr_kind_mod,  only: r8 => shr_kind_r8
-    use shr_const_mod, only: shr_const_g, shr_const_karman
-
-    implicit none
-
-    real(r8), parameter :: difair = 2.36e-5_r8          ! molecular diffusivity of air
-    real(r8), parameter :: muair  = 1.7e-5_r8           ! dynamic viscosity of air
-                                                     ! about 17 degC, 1.73 at STP (Salby)
-    real(r8), parameter :: gravit = shr_const_g      ! gravity
-    real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
-
-!---------------------------- Arguments --------------------------------
-    integer , intent(in)  :: isp   ! species flag
-    real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
-    real(r8), intent(in)  :: zbot  ! height of lowest level (m)
-    real(r8), intent(in)  :: ustar ! Friction velocity (m/s)
-!
-    real(r8), intent(out) :: alpkn ! kinetic fractionation factor (1-kmol)
-
-!------------------------- Local Variables -----------------------------
-    real(r8) z0                 ! roughness length (constant in cam 9.5e-5)
-    real(r8) reno               ! surface reynolds number
-    real(r8) tmr                ! ratio of turbulen to molecular resistance
-    real(r8) enn                ! diffusive power
-    real(r8) sc                 ! Schmidt number (Prandtl number)
-    real(r8) vmu                ! kinematic viscocity of air
-    real(r8) difn               ! ratio of difusivities to the power of n
-    real(r8) difrmj             ! isotopic diffusion with substitutions
-
-    real(r8) kmol               ! Merlivals k_mol
-!-----------------------------------------------------------------------
-!
-!!    difrmj = difrm(isp)/fisub(isp)
-    difrmj = difrm(isp)
-!
-      z0 = (ustar**2._r8)/(81.1_r8*gravit)  ! Charnock's equation
-      vmu = muair / rbot             ! kinematic viscosity
-      Sc  = vmu/difair
-      reno = ustar*z0 / vmu       ! reynolds number
-!
-      if (reno < recrit) then        ! Smooth (Re < 0.13)
-         enn = 2._r8/3._r8
-         tmr  = ( (1._r8/karman)*log(ustar*zbot / (30._r8 * vmu)) ) / (13.6_r8 * Sc**(2._r8/3._r8))
-      else                           ! Rough  (Re > 2)
-         enn = 1._r8/2._r8
-         tmr  = ( (1._r8/karman)*log(zbot/z0) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
-      end if
-
-      difn = (1._r8/difrmj)**enn        ! use D/Di, not Di/D
-      kmol = (difn - 1._r8) / (difn + tmr)
-
-      alpkn = 1._r8 - kmol
-
-    return
-  end subroutine wiso_kmol
 
 !=======================================================================
 ! Liquid/Vapor equilibrium fractionation functions
@@ -493,9 +354,9 @@ contains
 
 !=======================================================================
 
-!--------------------
-!Calculation routines
-!--------------------
+!------------------------------
+!Atmosphere/Ocean flux routines
+!------------------------------
 
 !=======================================================================
 
@@ -569,14 +430,14 @@ contains
 !--------------------------
 !
   alpha = wiso_liq_vap_equil_frac_factor(iso,ts)  !get equilibrium frac. factor
- ! call wiso_kmolv10(iso,ustar,alpkn)                   !get kinetic frac. factor
   call wiso_kmol(iso,rbot,zbot,ustar,alpkn)            !Advanced kinetic frac. routine
 
   if(rocn .eq. 0._r8) then                             !no ocean model data:
-    Roce = wiso_get_rstd(iso)                          !set to default value
+  ! Need to get 'roce' or 'rstd' from shr_wtracers_mod.
+    !    Roce = wiso_get_rstd(iso)                          !set to default value
   else                                                 !isotopic ocean model present:
-    R_std = wiso_get_rstd(iso)                         !pull ratio from ocean data
-    Roce = R_std*rocn
+!    R_std = wiso_get_rstd(iso)                         !pull ratio from ocean data
+!    Roce = R_std*rocn
   end if                                               !rocn value
 !
 !-----------------------------------------------
@@ -612,112 +473,92 @@ contains
 end subroutine wiso_flxoce
 
 !=======================================================================
-function wiso_ssatf(tk)
+  subroutine wiso_kmol(isp,rbot,zbot,ustar,alpkn)
 !-----------------------------------------------------------------------
-! Purpose: Compute supersaturation based on temperature parameterization.
-! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:14 MDT 2003
+!
+! Purpose: compute kinetic modifier for drag coefficient (Merlivat & Jouzel)
+!
+! Method:
+!   Code solves Brutsaert equations for theturbulent layer using GCM computed
+!   quantities.  Operates on a vector of points.
+!
+! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 14:05:38 MDT 2003
+!
 !-----------------------------------------------------------------------
-    real(r8), intent(in)  :: tk           ! temperature
-    real(r8) :: wiso_ssatf            ! return supersaturation
-!-----------------------------------------------------------------------
-#ifdef OLDWAY
-    wiso_ssatf = max(1.0_r8, fsata + fsatb*(tk-tzero))
-#else
-    wiso_ssatf = fsata + fsatb*(tk-tzero)
-!!    wiso_ssatf = max(wiso_ssatf, fsata)
-    wiso_ssatf = max(wiso_ssatf, 1.0_r8)
-    wiso_ssatf = min(wiso_ssatf, ssatmx)
-#endif
-    return
-end function wiso_ssatf
+    use shr_kind_mod,  only: r8 => shr_kind_r8
+    use shr_kind_mod,  only: cl => shr_kind_cl
+    use shr_const_mod, only: shr_const_g, shr_const_karman
+    use shr_sys_mod,   only: shr_sys_abort
 
-!----------------------
-!Data checking routines:
-!----------------------
+    implicit none
 
-!=======================================================================
-  function wiso_get_rstd(isp)
-!-----------------------------------------------------------------------
-! Purpose: Retrieve internal Rstd variable, based on species index
-! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:14 MDT 2003
-!-----------------------------------------------------------------------
-    integer , intent(in)  :: isp          ! species index
-    real(r8) :: wiso_get_rstd             ! return isotope ratio
-!-----------------------------------------------------------------------
-    wiso_get_rstd = rstd(isp)
-    return
-  end function wiso_get_rstd
+    real(r8), parameter :: difair = 2.36e-5_r8          ! molecular diffusivity of air
+    real(r8), parameter :: muair  = 1.7e-5_r8           ! dynamic viscosity of air
+                                                     ! about 17 degC, 1.73 at STP (Salby)
+    real(r8), parameter :: gravit = shr_const_g      ! gravity
+    real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
 
-!=======================================================================
-  function wiso_get_fisub(isp)
-!-----------------------------------------------------------------------
-! Purpose: Retrieve internal fisub variable, based on species index
-! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:28:52 MDT 2003
-!-----------------------------------------------------------------------
-    integer , intent(in)  :: isp         ! species index
-    real(r8) :: wiso_get_fisub           ! return number of substitutions
-!-----------------------------------------------------------------------
-    wiso_get_fisub = fisub(isp)
-    return
-  end function wiso_get_fisub
+!---------------------------- Arguments --------------------------------
+    integer , intent(in)  :: isp   ! species flag
+    real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
+    real(r8), intent(in)  :: zbot  ! height of lowest level (m)
+    real(r8), intent(in)  :: ustar ! Friction velocity (m/s)
+!
+    real(r8), intent(out) :: alpkn ! kinetic fractionation factor (1-kmol)
 
-!=======================================================================
-  function wiso_get_ispec(name)
+!------------------------- Local Variables -----------------------------
+    real(r8) z0                 ! roughness length (constant in cam 9.5e-5)
+    real(r8) reno               ! surface reynolds number
+    real(r8) tmr                ! ratio of turbulen to molecular resistance
+    real(r8) enn                ! diffusive power
+    real(r8) sc                 ! Schmidt number (Prandtl number)
+    real(r8) vmu                ! kinematic viscocity of air
+    real(r8) difn               ! ratio of difusivities to the power of n
+    real(r8) difrmj             ! isotopic diffusion with substitutions
+
+    real(r8) kmol               ! Merlivals k_mol
+
+    ! Character array to store abort error message
+    character(len=cl) :: abort_msg
+
+    real(r8), parameter :: recrit   = 1.0_r8  ! critical raynolds number for kmol
 !-----------------------------------------------------------------------
-! Purpose: Retrieve speciies index, based on species name
-! Author: Chuck Bardeen
-!-----------------------------------------------------------------------
-    character(len=*),  intent(in)  :: name  ! species name
-    integer  :: wiso_get_ispec              ! return species index
-!-----------------------------------------------------------------------
-    do wiso_get_ispec = 1, pwtspec
-      if (name == spnam(wiso_get_ispec)) then
-        return
+!
+    select case  (isp)
+      case(WATER_SPECIES_TYPE_BULK)
+        ! No kinetic fractionation for H2O
+        difrmj = 1._r8
+      case (WATER_SPECIES_TYPE_H218O)
+        difrmj = DIFF_RATIO_H218O
+      case (WATER_SPECIES_TYPE_H217O)
+        difrmj = DIFF_RATIO_H218O !NEED TO DOUBLE-CHECK!!!!
+      case (WATER_SPECIES_TYPE_HDO)
+        difrmj = DIFF_RATIO_HDO
+      case default
+        ! This situation shouldn't happen, so abort the run
+        write(abort_msg,'(a,i0)') 'wiso_kmol: ERROR: bad isotope species index; bad index = ', isp
+        call shr_sys_abort(abort_msg)
+    end select
+!
+      z0 = (ustar**2._r8)/(81.1_r8*gravit)  ! Charnock's equation
+      vmu = muair / rbot             ! kinematic viscosity
+      Sc  = vmu/difair
+      reno = ustar*z0 / vmu       ! reynolds number
+!
+      if (reno < recrit) then        ! Smooth (Re < 0.13)
+         enn = 2._r8/3._r8
+         tmr  = ( (1._r8/karman)*log(ustar*zbot / (30._r8 * vmu)) ) / (13.6_r8 * Sc**(2._r8/3._r8))
+      else                           ! Rough  (Re > 2)
+         enn = 1._r8/2._r8
+         tmr  = ( (1._r8/karman)*log(zbot/z0) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
       end if
-    end do
-    wiso_get_ispec = ispundef
-    return
-  end function wiso_get_ispec
 
-!=======================================================================
-  function wiso_ratio(isp,qiso,qtot)
-!-----------------------------------------------------------------------
-! Purpose: Compute isotopic ratio from masses, with numerical checks
-! Author David Noone <dcn@caltech.edu> - Tue Jul  1 08:32:45 MDT 2003
-!-----------------------------------------------------------------------
-    integer, intent(in)  :: isp         ! species index
-    real(r8),intent(in)  :: qiso        ! isotopic mass
-    real(r8),intent(in)  :: qtot        ! isotopic mass
-    real(r8) :: wiso_ratio              ! return value
-!-----------------------------------------------------------------------
-! TBD: This qtiny is different than found in the equivalent routine in
-! water _tracers. Also, this value is larger than the smallest support
-! mixing ratios, and probably should be made smaller so as not to
-! produce incorrect ratios for small values.
-    real(r8) :: qtiny = 1.e-16_r8
-!-----------------------------------------------------------------------
-    if (qtot > 0._r8) then
-      wiso_ratio = qiso/(qtot+qtiny)
-    else
-      wiso_ratio = qiso/(qtot-qtiny)
-    end if
-!!    wiso_ratio = espmw(isp)*wiso_ratio/fisum(isp)      ! correct!
-  end function wiso_ratio
+      difn = (1._r8/difrmj)**enn        ! use D/Di, not Di/D
+      kmol = (difn - 1._r8) / (difn + tmr)
 
-!=======================================================================
-  function wiso_delta(isp,qiso,qtot)
-!-----------------------------------------------------------------------
-! Purpose: Compute isotopic delta value from masses
-! Author David Noone <dcn@caltech.edu> - Tue Jul  1 08:32:45 MDT 2003
-!-----------------------------------------------------------------------
-    integer, intent(in)  :: isp         ! species index
-    real(r8),intent(in)  :: qiso        ! isotopic mass
-    real(r8),intent(in)  :: qtot        ! isotopic mass
-    real(r8) :: wiso_delta              ! return value
-!-----------------------------------------------------------------------
-    wiso_delta = 1000._r8 * (wiso_ratio(isp,qiso,qtot) / Rstd(isp) - 1._r8)
-    return
-  end function wiso_delta
+      alpkn = 1._r8 - kmol
+
+  end subroutine wiso_kmol
 
 !=========================================================================
 end module shr_wiso_mod

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -27,11 +27,6 @@ module shr_wiso_mod
 
   use shr_kind_mod,  only: r8 => shr_kind_r8
   use shr_const_mod, only: SHR_CONST_TKTRIP
-!                           SHR_CONST_RSTD_H2ODEV, &
-!                           SHR_CONST_VSMOW_16O, &
-!                           SHR_CONST_VSMOW_18O, &
-!                           SHR_CONST_VSMOW_D , &
-!                           SHR_CONST_VSMOW_H
 
   implicit none
   private
@@ -66,11 +61,6 @@ module shr_wiso_mod
                                  !aka number of iso. atoms per molec.
   public :: wiso_ratio           !calculate mass ratio of isotope .
   public :: wiso_delta           !calculate the delta value for isotopes.
-
-
-!configuration pointers/indices   (Added from water_tracers - JN)
-!  integer, public :: iwspec(pcnst+pnats)     ! flag for water (isotope) species
-!  integer, public :: ixwti, ixwtx     ! lowest and highest index to search
 
 ! Species indicies - public so thay can be seen by water_tracers
   integer, parameter, public  :: ispundef = 0    ! Undefined
@@ -142,22 +132,6 @@ module shr_wiso_mod
       aksmc = (/ 0._r8, 0._r8, 0.00528_r8,   0.006_r8    /), &
       akrfa = (/ 0._r8, 0._r8, 0.2508e-3_r8, 0.285e-3_r8 /), &
       akrfb = (/ 0._r8, 0._r8, 0.7216e-3_r8, 0.82e-3_r8  /)
-
-! Coefficients for fractionation
-! TBD: Check to make sure that the entries for h216o are correct.
-!From Majoube, 1971a:
-!  real(r8), parameter, dimension(pwtspec) :: &  ! liquid/vapour
-!      alpal = (/ 0._r8, 0._r8, 24.844e+3_r8, 1.137e+3_r8   /) , &
-!      alpbl = (/ 0._r8, 0._r8, -76.248_r8,   -0.4156_r8    /) , &
-!      alpcl = (/ 0._r8, 0._r8, 52.612e-3_r8, -2.0667e-3_r8 /)
-
-!From Horita and Wesolowski, 1994:
-  real(r8), parameter, dimension(pwtspec) :: &  ! liquid/vapour
-      alpal = (/ 0._r8, 0._r8, 1158.8e-12_r8, 0.35041e+6_r8 /), &
-      alpbl = (/ 0._r8, 0._r8, -1620.1e-9_r8, -1.6664e+3_r8 /), &
-      alpcl = (/ 0._r8, 0._r8, 794.84e-6_r8, 6.7123_r8      /), &
-      alpdl = (/ 0._r8, 0._r8, -161.04e-3_r8, -7.685e-3_r8  /), &
-      alpel = (/ 0._r8, 0._r8, 2.9992e+6_r8, 0._r8 /)
 
 !isoCAM3 values:
 !  real(r8), parameter, dimension(pwtspec) :: &  ! ice/vapour

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -54,7 +54,7 @@ real(r8), parameter, public :: DIFF_RATIO_H218O = 0.9727_r8
 ! Exponent value from:
 
 ! Barkan, E. and B. Luz,
-! Diffusivity fractionations of HO/HO and HO/HO in air and their implications for isotope hydrology
+! Diffusivity fractionations of H216O/H217O and H216O/H218O in air and their implications for isotope hydrology
 ! Rapid Communications in Mass Spectrometry, 21, 2999-3005, August 2007
 ! DOI: 10.1002/rcm.3180
 
@@ -90,7 +90,7 @@ contains
 
     ! Function input arguements
     integer , intent(in)        :: isp  ! water species type index (e.g., H2O, HDO, H218O)
-    real(r8), intent(in)        :: tk   ! Temperature (K)
+    real(r8), intent(in)        :: tk   ! Temperature [K]
 
     ! Return value (equilibrium fractionation factor)
     real(r8) :: equil_frac
@@ -148,7 +148,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Function input arguements
-    real(r8), intent(in)  :: tk   ! Temperature (K)
+    real(r8), intent(in)  :: tk   ! Temperature [K]
 
     ! Return value (HDO equilibrium fractionation factor)
     real(r8) :: equil_frac_HDO
@@ -187,7 +187,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Function input arguements
-    real(r8), intent(in)  :: tk   ! Temperature (K)
+    real(r8), intent(in)  :: tk   ! Temperature [K]
 
     ! Return value (H218O equilibrium fractionation factor)
     real(r8) :: equil_frac_18O
@@ -227,7 +227,7 @@ contains
 
     ! Function input arguements
     integer , intent(in)        :: isp  ! water species type index (e.g., H2O, HDO, H218O)
-    real(r8), intent(in)        :: tk   ! Temperature (K)
+    real(r8), intent(in)        :: tk   ! Temperature [K]
 
     ! Return value (equilibrium fractionation factor)
     real(r8) :: equil_frac
@@ -285,7 +285,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Function input arguements
-    real(r8), intent(in)  :: tk   ! Temperature (K)
+    real(r8), intent(in)  :: tk   ! Temperature [K]
 
     ! Return value (HDO equilibrium fractionation factor)
     real(r8) :: equil_frac_HDO
@@ -319,7 +319,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Function input arguements
-    real(r8), intent(in)  :: tk   ! Temperature (K)
+    real(r8), intent(in)  :: tk   ! Temperature [K]
 
     ! Return value (H218O equilibrium fractionation factor)
     real(r8) :: equil_frac_18O
@@ -548,7 +548,7 @@ contains
 
   !=======================================================================
 
-  pure function icam_atm_ocn_kinetic_frac_factor(iso,rbot,zbot,ustar, diff_ratio) result(alpkn)
+  pure function icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustar, diff_ratio) result(alpkn)
 
   !-----------------------------------------------------------------------
   !
@@ -565,25 +565,30 @@ contains
   ! Journal of Advances in Modeling Earth Systems, 9, 2, 949-977, June 2017
   ! DOI: 10.1002/2016MS000839
   !
+  ! Note:  The roughness length now comes from the atm/ocn flux scheme, and
+  !        is no longer calculated using equation 7 from Nusbaumer et al., 2017
+  !
   !-----------------------------------------------------------------------
     use shr_const_mod, only: gravit=>shr_const_g
     use shr_const_mod, only: karman=>shr_const_karman
 
+    ! Note:  Ideally these quantities would be calculate from
+    !        state variables or acquired from the atm/ocn scheme itself,
+    !        but for now just hard code it.
     real(r8), parameter :: difair = 2.36e-5_r8          ! molecular diffusivity of air
     real(r8), parameter :: muair  = 1.7e-5_r8           ! dynamic viscosity of air
                                                         ! about 17 degC, 1.73 at STP (Salby)
 
     !---------------------------- Arguments --------------------------------
-    integer , intent(in)  :: iso   ! species flag
-    real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)
-    real(r8), intent(in)  :: zbot  ! height of lowest level (m)
-    real(r8), intent(in)  :: ustar ! Friction velocity (m/s)
+    real(r8), intent(in)  :: rbot       ! density of lowest layer [kg m-3]
+    real(r8), intent(in)  :: zbot       ! height of lowest atmospheric layer [m]
+    real(r8), intent(in)  :: zoq        ! surface roughness length for water [m]
+    real(r8), intent(in)  :: ustar      ! friction velocity [m s-1]
     real(r8), intent(in)  :: diff_ratio ! isotopic diffusion ratio
 
     real(r8) :: alpkn ! kinetic fractionation factor (1-kmol)
 
     !------------------------- Local Variables -----------------------------
-    real(r8) z0                 ! roughness length (constant in cam 9.5e-5)
     real(r8) reno               ! surface reynolds number
     real(r8) tmr                ! ratio of turbulent to molecular resistance
     real(r8) enn                ! diffusive power
@@ -595,17 +600,16 @@ contains
     real(r8), parameter :: recrit   = 1.0_r8  ! critical Reynolds number for kmol
     !-----------------------------------------------------------------------
 
-    z0 = (ustar**2._r8)/(81.1_r8*gravit)  ! Charnock's equation
     vmu = muair / rbot                    ! kinematic viscosity
     Sc  = vmu/difair                      ! Schmidt number
-    reno = ustar*z0 / vmu                 ! Reynolds number
+    reno = ustar*zoq / vmu                ! Reynolds number
 
     if (reno < recrit) then ! Smooth regime (Re < 0.13)
       enn = 2._r8/3._r8
       tmr  = ( (1._r8/karman)*log(ustar*zbot / (30._r8 * vmu)) ) / (13.6_r8 * Sc**(2._r8/3._r8))
     else                    ! Rough regime (Re > 2)
       enn = 1._r8/2._r8
-      tmr  = ( (1._r8/karman)*log(zbot/z0) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
+      tmr  = ( (1._r8/karman)*log(zbot/zoq) - 5._r8) / (7.3_r8 * reno**(1._r8/4._r8) * Sc**(1._r8/2._r8))
     end if
 
     difn = (1._r8/diff_ratio)**enn        ! use D/Di, not Di/D

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -21,9 +21,6 @@ module shr_wiso_mod
 ! Module added to CESM's csm_share by:  Jesse Nusbaumer <nusbaume@colorado.edu> - March 2011
 !
 !-----------------------------------------------------------------------
-#undef NOFRAC          /* all fractionation factors = 1 */
-#undef NOKIN           /* all kinetic effects off */
-!-----------------------------------------------------------------------
 
   use shr_kind_mod,  only: r8 => shr_kind_r8
   use shr_const_mod, only: SHR_CONST_TKTRIP
@@ -33,15 +30,10 @@ module shr_wiso_mod
 
 ! Public interfaces
 
-  !Initialization routines:
-
-  public :: wiso_init            ! initilize water isotopes/tracers.
-  public :: wiso_get_ispec       ! lookup a species index by name
-
   !Fractionation routines:
 
   public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
-  public :: wiso_alpi            ! look-up ice/vapor equil. fractn.
+  public :: wiso_ice_vap_equil_frac_factor ! Function for calculating ice/vapor equilibrium fractionation factor
   public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
   public :: wiso_kmolv10         ! kmol (as above) from 10 meter wind (M&J)
   public :: wiso_akel            ! kinetic fractionation at liq. evaporation
@@ -57,12 +49,21 @@ module shr_wiso_mod
   !Data checking routines:
 
   public :: wiso_get_rstd        !retrive standard isotope ratio
+  public :: wiso_get_ispec       !lookup a species index by name
   public :: wiso_get_fisub       !retrive isotope subsitutions
                                  !aka number of iso. atoms per molec.
   public :: wiso_ratio           !calculate mass ratio of isotope .
   public :: wiso_delta           !calculate the delta value for isotopes.
 
 ! Species indicies - public so thay can be seen by water_tracers
+!NOTE: THESE SHOULD COME FROM 'shr_wtracer_mod.F90' once the share PR has been merged!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  FIX THIS BEFORE OPENING PR!
+  integer, parameter :: WATER_SPECIES_TYPE_BULK = 0  ! This one is special: total/bulk water rather than a species
+  integer, parameter :: WATER_SPECIES_TYPE_H218O = 1
+  integer, parameter :: WATER_SPECIES_TYPE_H217O = 2
+  integer, parameter :: WATER_SPECIES_TYPE_HDO = 3
+  integer, parameter :: WATER_SPECIES_TYPE_MAXVAL = 3
+
+  !DELETE WHEN THESE PARAMETERS NO LONGER EXIST IN THIS FILE!!!!
   integer, parameter, public  :: ispundef = 0    ! Undefined
   integer, parameter, public  :: isph2o   = 1    ! H2O    ! "regular" water
   integer, parameter, public  :: isph216o = 2    ! H216O  ! H216O, nearly the same as "regular" water
@@ -133,33 +134,7 @@ module shr_wiso_mod
       akrfa = (/ 0._r8, 0._r8, 0.2508e-3_r8, 0.285e-3_r8 /), &
       akrfb = (/ 0._r8, 0._r8, 0.7216e-3_r8, 0.82e-3_r8  /)
 
-!isoCAM3 values:
-!  real(r8), parameter, dimension(pwtspec) :: &  ! ice/vapour
-!      alpai = (/ 0._r8, 0._r8, 16288._r8,   0._r8         /), &
-!      alpbi = (/ 0._r8, 0._r8, 0._r8,       11.839_r8     /), &
-!      alpci = (/ 0._r8, 0._r8, -9.34e-2_r8, -28.224e-3_r8 /)
-
-!From Merlivat & Nief,1967 for HDO, and Majoube, 1971b for H218O:
- real(r8), parameter, dimension(pwtspec) :: &  ! ice/vapour
-      alpai = (/ 0._r8, 0._r8, 16289._r8,   0._r8         /), &
-      alpbi = (/ 0._r8, 0._r8, 0._r8,       11.839_r8     /), &
-      alpci = (/ 0._r8, 0._r8, -9.45e-2_r8, -28.224e-3_r8 /)
-
 contains
-
-!-----------------------
-!Initialization routines:
-!-----------------------
-
-!=======================================================================
-  subroutine wiso_init
-!-----------------------------------------------------------------------
-! Purpose: Initialize module internal data arrays
-! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:26 MDT 2003
-!-----------------------------------------------------------------------
-    write(6,*) 'WISO_INIT: Initializing water isotopes.'
-    return
-  end subroutine wiso_init
 
 !----------------------
 !Fractionation routines:
@@ -231,10 +206,6 @@ contains
 
       alpkn = 1._r8 - kmol
 
-#ifdef NOKIN
-!      alpkn = 1._r8
-#endif
-!
     return
   end subroutine wiso_kmol
 
@@ -287,11 +258,7 @@ contains
       end if
 !
       alpkn = 1._r8 - kmol
-!
-!#ifdef NOKIN
-!      alpkn = 1.0_r8
-!#endif
-!
+
     return
   end subroutine wiso_kmolv10
 
@@ -311,7 +278,7 @@ contains
     use shr_sys_mod,  only: shr_sys_abort
 
     ! Function input arguements
-    integer , intent(in)        :: isp  ! species index
+    integer , intent(in)        :: isp  ! water species type index (e.g., H2O, HDO, H218O)
     real(r8), intent(in)        :: tk   ! Temperature (K)
 
     ! Return value (equilibrium fractionation factor)
@@ -323,22 +290,19 @@ contains
     !-----------------------------------------------------------------------
 
     ! Initialize the fractionation factor to a huge negative (unphysical) value:
-    equil_frac = -huge(1._r8)
+    equil_frac = huge(-1._r8)
 
     select case  (isp)
-      case(isph2o)
+      case(WATER_SPECIES_TYPE_BULK)
         ! No fractionation for H2O
         equil_frac = 1._r8
-      case (isphdo)
+      case (WATER_SPECIES_TYPE_HDO)
         ! Equation 5 in Horita and Wesolowski, 1994
         equil_frac = horita_wesolowski_frac_factor_HDO(tk)
-      case (isph218o)
-        ! Equation 6 in Horit and Wesolowski, 1994
+      case (WATER_SPECIES_TYPE_H218O)
+        ! Equation 6 in Horita and Wesolowski, 1994
         equil_frac = horita_wesolowski_frac_factor_18O(tk)
       case default
-        ! This situation shouldn't happen, so return a giant negative factor (which is unphysical)
-        !equil_frac = -huge(1._r8)
-
         ! This situation shouldn't happen, so abort the run
         write(abort_msg,'(a,i0)') 'wiso_liq_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = ', isp
         call shr_sys_abort(abort_msg)
@@ -426,28 +390,121 @@ contains
 ! Ice/Vapor equilibrium fractionation functions
 !=======================================================================
 
-  function wiso_alpi(isp,tk)
-!-----------------------------------------------------------------------
-! Purpose: return ice/vapour fractionation from loop-up tables
-! Author:  David Noone <dcn@caltech.edu> - Tue Jul  1 12:02:24 MDT 2003
-!-----------------------------------------------------------------------
-    integer , intent(in)        :: isp  ! species indes
-    real(r8), intent(in)        :: tk   ! temperature (k)
-    real(r8) :: wiso_alpi               ! return fractionation
-!-----------------------------------------------------------------------
-    if (isp == isph2o) then
-      wiso_alpi = 1._r8
-      return
-    end if
+  function wiso_ice_vap_equil_frac_factor(isp,tk) result(equil_frac)
 
-    wiso_alpi = exp(alpai(isp)/tk**2 + alpbi(isp)/tk + alpci(isp))
+    !-----------------------------------------------------------------------
+    ! Public function that returns ice/vapor equilibrium
+    ! fractionation factor given the temperature and a
+    ! water isotope (isotopologue) species index.
+    !-----------------------------------------------------------------------
 
-#ifdef NOFRAC
-    wiso_alpi = 1._r8
-#endif
-!
-    return
-end function wiso_alpi
+    use shr_kind_mod, only: cl=>shr_kind_cl
+    use shr_sys_mod,  only: shr_sys_abort
+
+    ! Function input arguements
+    integer , intent(in)        :: isp  ! water species type index (e.g., H2O, HDO, H218O)
+    real(r8), intent(in)        :: tk   ! Temperature (K)
+
+    ! Return value (equilibrium fractionation factor)
+    real(r8) :: equil_frac
+
+    ! Character array to store abort error message
+    character(len=cl) :: abort_msg
+
+    !-----------------------------------------------------------------------
+
+    ! Initialize the fractionation factor to a huge negative (unphysical) value:
+    equil_frac = huge(-1._r8)
+
+    select case  (isp)
+      case(WATER_SPECIES_TYPE_BULK)
+        ! No fractionation for H2O
+        equil_frac = 1._r8
+      case (WATER_SPECIES_TYPE_HDO)
+        ! Equation 5 in Merlivat and Nief, 1967
+        equil_frac = merlivat_nief_frac_factor_HDO(tk)
+      case (WATER_SPECIES_TYPE_H218O)
+        ! Equation from Majoube, 1971
+        equil_frac = majoube_frac_factor_18O(tk)
+      case default
+        ! This situation shouldn't happen, so abort the run
+        write(abort_msg,'(a,i0)') 'wiso_ice_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = ', isp
+        call shr_sys_abort(abort_msg)
+    end select
+
+  end function wiso_ice_vap_equil_frac_factor
+
+!++++++++
+
+  pure function merlivat_nief_frac_factor_HDO(tk) result(equil_frac_HDO)
+
+    !-----------------------------------------------------------------------
+    ! Calculate ice/vapor equilibrium fractionation for HDO
+    !
+    ! Citation:
+    !
+    ! Equation 5 in:
+    !
+    ! Merlivat, L. and G. Nief,
+    ! Isotopic fractionation during change of state solid-vapour and liquid-vapour of water at temperatures below 0 degree C
+    ! Tellus, 19, 122-126, February 1967
+    ! DOI: 10.3402/tellusa.v19i1.9756
+    !
+    !-----------------------------------------------------------------------
+
+    ! Function input arguements
+    real(r8), intent(in)  :: tk   ! Temperature (K)
+
+    ! Return value (HDO equilibrium fractionation factor)
+    real(r8) :: equil_frac_HDO
+
+    ! Equation 5 (HDO) parameters:
+    real(r8), parameter ::   &
+      alpal_HDO = -9.45e-2_r8, &
+      alpbl_HDO = 16289._r8
+
+    !-----------------------------------------------------------------------
+
+    ! Equation 5 in Merlivat and Nief, 1967
+    equil_frac_HDO = exp(alpal_HDO + alpbl_HDO/tk**2)
+
+  end function merlivat_nief_frac_factor_HDO
+
+!++++++++
+
+  pure function majoube_frac_factor_18O(tk) result(equil_frac_18O)
+
+    !-----------------------------------------------------------------------
+    ! Calculate ice/vapor equilibrium fractionation for H218O
+    !
+    ! Citation:
+    !
+    ! Majoube, M.
+    ! Fractionnement en oxygene 18 et en deutérium entre l'eau et sa vapeur
+    ! Journal de Chimie Physique, 68, 1423–1436, 1971
+    ! DOI: 10.1051/jcp/1971681423
+    !
+    !-----------------------------------------------------------------------
+
+    ! Function input arguements
+    real(r8), intent(in)  :: tk   ! Temperature (K)
+
+    ! Return value (H218O equilibrium fractionation factor)
+    real(r8) :: equil_frac_18O
+
+    ! H218O equation parameters:
+    real(r8), parameter ::       &
+      alpal_18O = -28.224e-3_r8, &
+      alpbl_18O = 11.839_r8
+
+    !-----------------------------------------------------------------------
+
+    ! Equation from Majoube, 1971
+    equil_frac_18O = exp(alpal_18O + alpbl_18O/tk)
+
+  end function majoube_frac_factor_18O
+
+!=======================================================================
 
 !=======================================================================
 function wiso_akel(isp,tk,hum0,alpeq)
@@ -480,10 +537,6 @@ function wiso_akel(isp,tk,hum0,alpeq)
 ! Modify for non-standard isotope
 !
 !!    wiso_akel = wiso_akel**expk(isp)
-
-#ifdef NOKIN
-    wiso_akel = alpeq
-#endif
 
     return
 end function wiso_akel
@@ -518,10 +571,6 @@ end function wiso_akel
 ! Modify for non-standard isotope
 !
 !!    wiso_akci = wiso_akci**expk(isp)
-
-#ifdef NOKIN
-    wiso_akci = alpeq
-#endif
 !
     return
 end function wiso_akci

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -12,10 +12,6 @@ module shr_wiso_mod
 !-----------------------------------------------------------------------
 
   use shr_kind_mod,     only: r8 => shr_kind_r8
-  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
-  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
-  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
-  use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
 
   implicit none
   private
@@ -28,6 +24,10 @@ module shr_wiso_mod
 
   public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
   public :: wiso_ice_vap_equil_frac_factor ! Function for calculating ice/vapor equilibrium fractionation factor
+
+  ! Generic isotope property query routines (used by most/all component models):
+
+  public :: wiso_get_diffusivity_ratio     ! Function for querying the water isotope molecular diffusivity ratio
 
   !Atmosphere-Ocean flux calculation routines (used only by the atm/ocn flux modules):
 
@@ -46,8 +46,8 @@ module shr_wiso_mod
 ! Journal of Chemical Physics, 69, 2864-2871, September 1978
 ! DOI: 10.1063/1.436884
 
-real(r8), parameter :: DIFF_RATIO_HDO   = 0.9757_r8
-real(r8), parameter :: DIFF_RATIO_H218O = 0.9727_r8
+real(r8), parameter, public :: DIFF_RATIO_HDO   = 0.9757_r8
+real(r8), parameter, public :: DIFF_RATIO_H218O = 0.9727_r8
 
 ! Diffusivity ratio for H217O relative to H216O:
 
@@ -58,7 +58,7 @@ real(r8), parameter :: DIFF_RATIO_H218O = 0.9727_r8
 ! Rapid Communications in Mass Spectrometry, 21, 2999-3005, August 2007
 ! DOI: 10.1002/rcm.3180
 
-real(r8), parameter :: DIFF_RATIO_H217O = DIFF_RATIO_H218O**0.5185
+real(r8), parameter, public :: DIFF_RATIO_H217O = DIFF_RATIO_H218O**0.5185
 
 !=======================================================================
 
@@ -82,6 +82,11 @@ contains
 
     use shr_kind_mod, only: cl=>shr_kind_cl
     use shr_sys_mod,  only: shr_sys_abort
+
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
 
     ! Function input arguements
     integer , intent(in)        :: isp  ! water species type index (e.g., H2O, HDO, H218O)
@@ -214,6 +219,11 @@ contains
 
     use shr_kind_mod, only: cl=>shr_kind_cl
     use shr_sys_mod,  only: shr_sys_abort
+
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
 
     ! Function input arguements
     integer , intent(in)        :: isp  ! water species type index (e.g., H2O, HDO, H218O)
@@ -364,6 +374,61 @@ contains
 
 !=======================================================================
 
+!-------------------------------------
+!Isotope property query routines:
+!-------------------------------------
+
+!=======================================================================
+
+  function wiso_get_diffusivity_ratio(isp) result(diff_ratio)
+
+    !-----------------------------------------------------------------------
+    ! Public function that returns the molecular diffusivity ratio of a
+    ! water isotopologue relative to H216O, given a water isotope species index.
+    !-----------------------------------------------------------------------
+
+    use shr_kind_mod, only: cl=>shr_kind_cl
+    use shr_sys_mod,  only: shr_sys_abort
+
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
+
+    ! Function input arguments
+    integer, intent(in) :: isp  ! water species type index (e.g., H2O, HDO, H218O)
+
+    ! Return value (molecular diffusivity ratio relative to H216O)
+    real(r8) :: diff_ratio
+
+    ! Character array to store abort error message
+    character(len=cl) :: abort_msg
+
+    !-----------------------------------------------------------------------
+
+    ! Initialize the diffusion ratio to a huge negative (unphysical) value:
+    diff_ratio = huge(-1._r8)
+
+    select case (isp)
+      case(WATER_SPECIES_TYPE_BULK)
+        ! No kinetic fractionation for H2O
+        diff_ratio = 1._r8
+      case (WATER_SPECIES_TYPE_H218O)
+        diff_ratio = DIFF_RATIO_H218O
+      case (WATER_SPECIES_TYPE_H217O)
+        diff_ratio = DIFF_RATIO_H217O
+      case (WATER_SPECIES_TYPE_HDO)
+        diff_ratio = DIFF_RATIO_HDO
+      case default
+        ! This situation shouldn't happen, so abort the run
+        write(abort_msg,'(a,i0)') 'wiso_get_diffusivity_ratio: ERROR: bad isotope species index; bad index = ', isp
+        call shr_sys_abort(abort_msg)
+    end select
+
+  end function wiso_get_diffusivity_ratio
+
+!=======================================================================
+
 !------------------------------
 !Atmosphere/Ocean flux routines
 !------------------------------
@@ -403,6 +468,11 @@ contains
 
     use shr_kind_mod, only: cl=>shr_kind_cl
     use shr_sys_mod,  only: shr_sys_abort
+
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
+    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
 
     integer , intent(in)  :: iso   ! isotope species index
     real(r8), intent(in)  :: rbot  ! density of lowest layer (kg/m3)

--- a/src/water_isotopes/shr_wiso_mod.F90
+++ b/src/water_isotopes/shr_wiso_mod.F90
@@ -35,13 +35,11 @@ module shr_wiso_mod
   public :: wiso_liq_vap_equil_frac_factor ! Function for calculating liquid/vapor equilibrium fractionation factor
   public :: wiso_ice_vap_equil_frac_factor ! Function for calculating ice/vapor equilibrium fractionation factor
   public :: wiso_kmol            ! kinetic effects for ocean evap (Brutsaert)
-  public :: wiso_kmolv10         ! kmol (as above) from 10 meter wind (M&J)
   public :: wiso_akel            ! kinetic fractionation at liq. evaporation
   public :: wiso_akci            ! kinetic fractnation at ice condensation
 
   !Calculation routines:
 
-  public :: wiso_get_roce        ! retrive ocean isotope ratio.
   public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
   public :: wiso_ssatf           ! supersaturation function
   public :: wiso_heff            ! effective humidity function
@@ -61,7 +59,6 @@ module shr_wiso_mod
   integer, parameter :: WATER_SPECIES_TYPE_H218O = 1
   integer, parameter :: WATER_SPECIES_TYPE_H217O = 2
   integer, parameter :: WATER_SPECIES_TYPE_HDO = 3
-  integer, parameter :: WATER_SPECIES_TYPE_MAXVAL = 3
 
   !DELETE WHEN THESE PARAMETERS NO LONGER EXIST IN THIS FILE!!!!
   integer, parameter, public  :: ispundef = 0    ! Undefined
@@ -121,18 +118,22 @@ module shr_wiso_mod
 !     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_VSMOW_16O, SHR_CONST_VSMOW_D, SHR_CONST_VSMOW_18O /)   ! natural abundance
 !     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV /)   !all 1.0
 
-! Isotope enrichment at ocean surface (better to be computed or read from file)
-  real(r8), dimension(pwtspec), parameter :: &  ! mean ocean surface enrichent
-!      boce  = (/ 1._r8, 1._r8, 1.004_r8, 1.0005_r8 /)
-!      boce  = (/ 1._r8, 1._r8, 1.0128_r8, 1.0016_r8, 1.0008_r8, 1.00671_r8 /)  ! LGM
-      boce  = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)
-
 ! Ocean surface kinetic fractionation parameters for M&J method:
 ! TBD: Check to make sure that the entries for h216o are correct.
   real(r8), parameter, dimension(pwtspec) :: &  ! surface kinetic exchange
       aksmc = (/ 0._r8, 0._r8, 0.00528_r8,   0.006_r8    /), &
       akrfa = (/ 0._r8, 0._r8, 0.2508e-3_r8, 0.285e-3_r8 /), &
       akrfb = (/ 0._r8, 0._r8, 0.7216e-3_r8, 0.82e-3_r8  /)
+
+! Interface definition for H218O equilibirum fractionation function,
+! so that the functions can then be passed into the H217O fractionation function.
+  abstract interface
+    pure function H218O_equil_func(tk) result(equil_frac_18O)
+      use, intrinsic :: iso_fortran_env, only: real64
+      real(real64), intent(in) :: tk ! Temperature (K)
+      real(real64) :: equil_frac_18O
+    end function
+  end interface
 
 contains
 
@@ -210,59 +211,6 @@ contains
   end subroutine wiso_kmol
 
 !=======================================================================
-  subroutine wiso_kmolv10(isp,ustar,alpkn)
-!-----------------------------------------------------------------------
-!
-! Purpose: compute kinetic modifier for drag coefficient (Merlivat &
-! Jouzel, 1979)
-!
-! Method:
-!    Uses everyones favorite empirical relation to 10 meter windspeed
-!
-! Author: David Noone <dcn@caltech.edu> - Mon Jun 30 14:05:38 MDT 2003
-!
-! Modified U(z=10 m) calculation: Jesse Nusbaumer <nusbaume@colorado.edu> - Sept.
-! 2011
-!
-!-----------------------------------------------------------------------
-    use shr_kind_mod, only: r8 => shr_kind_r8
-    use shr_const_mod, only: shr_const_g, shr_const_karman
-
-    implicit none
-
-    real(r8), parameter :: gravit = shr_const_g      ! gravity
-    real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
-
-!---------------------------- Arguments --------------------------------
-    integer , intent(in)  :: isp          ! species flag
-    real(r8), intent(in)  :: ustar        !friction velocity
-!
-    real(r8), intent(out) :: alpkn ! kinetic fractionation fatcor
-
-!------------------------- Local Variables -----------------------------
-    real(r8) z0                 ! roughness length
-    real(r8) v10                ! 10 meter winds
-    real(r8) kmol               ! Merlivat's K_mol
-!-----------------------------------------------------------------------
-!
-    z0 = (ustar**2._r8)/(81.1_r8*gravit)      ! Charnock's equation
-!
-    v10 = ustar*log(10._r8/z0)/karman  !calculate U(z=10 m) wind speed.
-!
-! Compute the kinetic fractionation:
-!
-      if (v10 < 7.0_r8) then              ! smooth regime
-         kmol = aksmc(isp)
-      else                             ! rough regime
-         kmol = akrfa(isp)*v10 + akrfb(isp)
-      end if
-!
-      alpkn = 1._r8 - kmol
-
-    return
-  end subroutine wiso_kmolv10
-
-!=======================================================================
 ! Liquid/Vapor equilibrium fractionation functions
 !=======================================================================
 
@@ -296,12 +244,15 @@ contains
       case(WATER_SPECIES_TYPE_BULK)
         ! No fractionation for H2O
         equil_frac = 1._r8
-      case (WATER_SPECIES_TYPE_HDO)
-        ! Equation 5 in Horita and Wesolowski, 1994
-        equil_frac = horita_wesolowski_frac_factor_HDO(tk)
       case (WATER_SPECIES_TYPE_H218O)
         ! Equation 6 in Horita and Wesolowski, 1994
         equil_frac = horita_wesolowski_frac_factor_18O(tk)
+      case (WATER_SPECIES_TYPE_H217O)
+        ! Equation 3 from Barkan and Luz, 2005
+        equil_frac = barkan_luz_frac_factor_17O(tk, horita_wesolowski_frac_factor_18O)
+      case (WATER_SPECIES_TYPE_HDO)
+        ! Equation 5 in Horita and Wesolowski, 1994
+        equil_frac = horita_wesolowski_frac_factor_HDO(tk)
       case default
         ! This situation shouldn't happen, so abort the run
         write(abort_msg,'(a,i0)') 'wiso_liq_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = ', isp
@@ -420,12 +371,15 @@ contains
       case(WATER_SPECIES_TYPE_BULK)
         ! No fractionation for H2O
         equil_frac = 1._r8
-      case (WATER_SPECIES_TYPE_HDO)
-        ! Equation 5 in Merlivat and Nief, 1967
-        equil_frac = merlivat_nief_frac_factor_HDO(tk)
       case (WATER_SPECIES_TYPE_H218O)
         ! Equation from Majoube, 1971
         equil_frac = majoube_frac_factor_18O(tk)
+      case (WATER_SPECIES_TYPE_H217O)
+        ! Equation 3 from Barkan and Luz, 2005
+        equil_frac = barkan_luz_frac_factor_17O(tk, majoube_frac_factor_18O)
+      case (WATER_SPECIES_TYPE_HDO)
+        ! Equation 5 in Merlivat and Nief, 1967
+        equil_frac = merlivat_nief_frac_factor_HDO(tk)
       case default
         ! This situation shouldn't happen, so abort the run
         write(abort_msg,'(a,i0)') 'wiso_ice_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = ', isp
@@ -505,6 +459,40 @@ contains
   end function majoube_frac_factor_18O
 
 !=======================================================================
+! H217O equilibrium fractionation function
+!=======================================================================
+
+  pure function barkan_luz_frac_factor_17O(tk, equil_func_18O) result(equil_frac_17O)
+
+    !-----------------------------------------------------------------------
+    ! Calculate equilibrium fractionation factor for H217O (all phase changes)
+    !
+    ! Citation:
+    !
+    ! Equation 3 in:
+    !
+    ! Barkan, E. and Luz, B.,
+    ! High precision measurements of 17O/16O and 18O/16O ratios in H2O
+    ! Rapid Communications in Mass Spectrometry, 19, 3737-3742, November 2005
+    ! DOI: 10.1002/rcm.2250
+    !
+    !-----------------------------------------------------------------------
+
+    ! Function input arguements
+    real(r8), intent(in) :: tk                    ! Temperature (K)
+    procedure(H218O_equil_func) :: equil_func_18O ! Function to calculate 18O equilibrium fractionation
+
+    ! Return value (H217O equilibrium fractionation factor)
+    real(r8) :: equil_frac_17O
+
+    ! Equation 3 parameters:
+    real(r8), parameter :: theta = 0.529_r8
+
+    !-----------------------------------------------------------------------
+
+    equil_frac_17O = equil_func_18O(tk)**theta
+
+  end function barkan_luz_frac_factor_17O 
 
 !=======================================================================
 function wiso_akel(isp,tk,hum0,alpeq)
@@ -580,21 +568,6 @@ end function wiso_akci
 !--------------------
 
 !=======================================================================
-  function wiso_get_roce(isp)
-!-----------------------------------------------------------------------
-! Purpose: Retrieve internal Roce variable, based on species index
-! Author: David Noone <dcn@caltech.edu> - Sun Jun 29 20:29:04 MDT 2003
-!-----------------------------------------------------------------------
-    integer , intent(in)  :: isp          ! species index
-    real(r8) :: wiso_get_roce             ! return isotope ratio
-!-----------------------------------------------------------------------
-    wiso_get_roce = boce(isp)*rstd(isp)
-    return
-  end function wiso_get_roce
-
-!=======================================================================
-
-!=======================================================================
 
  subroutine wiso_flxoce( iso  ,rbot   ,zbot   ,wtbot   , &
                          ts     , rocn, ustar  ,re , &
@@ -629,7 +602,7 @@ end function wiso_akci
 !-----------------------------------------------------------------------
 !  use shr_kind_mod, only: r8 => shr_kind_r8
 !  use water_tracers, only: trace_water, wtrc_is_vap, iwspec, ixwti, ixwtx
-!  use water_isotopes, only: wisotope, wiso_kmol, wiso_get_roce, &
+!  use water_isotopes, only: wisotope, wiso_kmol, &
 !                              wiso_alpi
 
   implicit none
@@ -670,7 +643,7 @@ end function wiso_akci
   call wiso_kmol(iso,rbot,zbot,ustar,alpkn)            !Advanced kinetic frac. routine
 
   if(rocn .eq. 0._r8) then                             !no ocean model data:
-    Roce = wiso_get_roce(iso)                          !set to default value
+    Roce = wiso_get_rstd(iso)                          !set to default value
   else                                                 !isotopic ocean model present:
     R_std = wiso_get_rstd(iso)                         !pull ratio from ocean data
     Roce = R_std*rocn

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -20,6 +20,8 @@ add_subdirectory(shr_vmath_test)
 
 add_subdirectory(shr_wtracers_test)
 
+add_subdirectory(shr_wiso_test)
+
 add_subdirectory(shr_wv_sat_test)
 
 add_subdirectory(shr_precip_test)

--- a/test/unit/shr_wiso_test/CMakeLists.txt
+++ b/test/unit/shr_wiso_test/CMakeLists.txt
@@ -4,24 +4,17 @@ set (pf_sources
 
 set(sources_needed
    shr_wiso_mod.F90
+   shr_wtracers_mod.F90
    shr_kind_mod.F90
    shr_const_mod.F90
    shr_sys_mod.nompi_abortthrows.F90
    shr_abort_mod.abortthrows.F90
    )
 
-
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
-
-# This is needed to make ESMF_Stubs.F90 avoid pulling in mpi
-add_definitions(-DHIDE_MPI)
 
 add_pfunit_ctest(shr_wiso
   TEST_SOURCES "${pf_sources}"
   OTHER_SOURCES "${test_sources}")
 
 declare_generated_dependencies(shr_wiso "${share_genf90_sources}")
-
-#target_link_libraries(shr_wtracers esmf)
-# The following adds all dependencies of ESMF, including PIO, NetCDF, etc.:
-#target_link_libraries(shr_wtracers ESMF::ESMF)

--- a/test/unit/shr_wiso_test/CMakeLists.txt
+++ b/test/unit/shr_wiso_test/CMakeLists.txt
@@ -1,0 +1,22 @@
+set (pf_sources
+  test_shr_wiso.pf
+  )
+
+set(sources_needed
+   shr_wiso_mod.F90
+   shr_kind_mod.F90
+   shr_const_mod.F90
+   )
+
+
+extract_sources("${sources_needed}" "${share_sources}" test_sources)
+
+add_pfunit_ctest(shr_wiso
+  TEST_SOURCES "${pf_sources}"
+  OTHER_SOURCES "${test_sources}")
+
+declare_generated_dependencies(shr_wiso "${share_genf90_sources}")
+
+#target_link_libraries(shr_wtracers esmf)
+# The following adds all dependencies of ESMF, including PIO, NetCDF, etc.:
+#target_link_libraries(shr_wtracers ESMF::ESMF)

--- a/test/unit/shr_wiso_test/CMakeLists.txt
+++ b/test/unit/shr_wiso_test/CMakeLists.txt
@@ -6,10 +6,15 @@ set(sources_needed
    shr_wiso_mod.F90
    shr_kind_mod.F90
    shr_const_mod.F90
+   shr_sys_mod.nompi_abortthrows.F90
+   shr_abort_mod.abortthrows.F90
    )
 
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
+
+# This is needed to make ESMF_Stubs.F90 avoid pulling in mpi
+add_definitions(-DHIDE_MPI)
 
 add_pfunit_ctest(shr_wiso
   TEST_SOURCES "${pf_sources}"

--- a/test/unit/shr_wiso_test/CMakeLists.txt
+++ b/test/unit/shr_wiso_test/CMakeLists.txt
@@ -13,6 +13,9 @@ set(sources_needed
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
 
+# This is needed to make ESMF_Stubs.F90 avoid pulling in mpi
+add_definitions(-DHIDE_MPI)
+
 add_pfunit_ctest(shr_wiso
   TEST_SOURCES "${pf_sources}"
   OTHER_SOURCES "${test_sources}")

--- a/test/unit/shr_wiso_test/CMakeLists.txt
+++ b/test/unit/shr_wiso_test/CMakeLists.txt
@@ -4,7 +4,6 @@ set (pf_sources
 
 set(sources_needed
    shr_wiso_mod.F90
-   shr_wtracers_mod.F90
    shr_kind_mod.F90
    shr_const_mod.F90
    shr_sys_mod.nompi_abortthrows.F90
@@ -12,9 +11,6 @@ set(sources_needed
    )
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
-
-# This is needed to make ESMF_Stubs.F90 avoid pulling in mpi
-add_definitions(-DHIDE_MPI)
 
 add_pfunit_ctest(shr_wiso
   TEST_SOURCES "${pf_sources}"

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -44,7 +44,7 @@ contains
 
       class(TestShrWiso), intent(inout) :: this
 
-      integer, parameter :: h2o_spec_idx = 1
+      integer, parameter :: h2o_spec_idx = 0
 
       real(r8)           :: h2o_liq_vap_frac
 
@@ -75,12 +75,58 @@ contains
       ! Try using a bad isotope index:
       bad_idx_frac = wiso_liq_vap_equil_frac_factor(bad_spec_idx, 273.15_r8)
 
-      ! Check that the fractionation factor is negative huge:
-      !@assertEqual(-huge(1._r8), bad_idx_frac)
-
       ! Check that an exception was raised:
       @assertExceptionRaised("ABORTED: wiso_liq_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = 78")
 
    end subroutine test_shr_wiso_liq_vap_equil_frac_factor_bad_idx
+
+  ! ------------------------------------------------------------------------
+  ! Tests of wiso_ice_vap_equil_frac_factor function
+  ! ------------------------------------------------------------------------
+
+   @Test
+   subroutine test_shr_wiso_ice_vap_equil_frac_factor_h2o(this)
+      ! Test that the ice/vapor equilibrium fractionation factor
+      ! function produces correct values for H2O.
+
+      use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
+
+      class(TestShrWiso), intent(inout) :: this
+
+      integer, parameter :: h2o_spec_idx = 0
+
+      real(r8)           :: h2o_ice_vap_frac
+
+      ! Calculate the fractionation factor for H216O (H2O):
+      h2o_ice_vap_frac = wiso_ice_vap_equil_frac_factor(h2o_spec_idx, 273.15_r8)
+
+      ! Check that a bulk (H2O) water species always returns one:
+      @assertEqual(1._r8, h2o_ice_vap_frac)
+
+   end subroutine test_shr_wiso_ice_vap_equil_frac_factor_h2o
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_ice_vap_equil_frac_factor_bad_idx(this)
+      ! Test that the ice/vapor equilibrium fractionation factor
+      ! function raises an exception when given a bad isotope species
+      ! index.
+
+      use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
+
+      class(TestShrWiso), intent(inout) :: this
+
+      integer, parameter :: bad_spec_idx = 78
+
+      real(r8)           :: bad_idx_frac
+
+      ! Try using a bad isotope index:
+      bad_idx_frac = wiso_ice_vap_equil_frac_factor(bad_spec_idx, 273.15_r8)
+
+      ! Check that an exception was raised:
+      @assertExceptionRaised("ABORTED: wiso_ice_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = 78")
+
+   end subroutine test_shr_wiso_ice_vap_equil_frac_factor_bad_idx
 
 end module test_shr_wiso

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -1,0 +1,58 @@
+module test_shr_wiso
+
+   ! Tests of shr_wiso_mod
+
+   use funit
+   use shr_wiso_mod
+   use shr_kind_mod, only: r8=>SHR_KIND_R8
+
+   implicit none
+
+   @TestCase
+   type, extends(TestCase) :: TestShrWiso
+   contains
+      procedure :: setUp
+      procedure :: tearDown
+   end type TestShrWiso
+
+contains
+
+  subroutine setUp(this)
+     class(TestShrWiso), intent(inout) :: this
+  end subroutine setUp
+
+  subroutine tearDown(this)
+     class(TestShrWiso), intent(inout) :: this
+
+     !integer :: rc
+
+     !if (shr_wtracers_initialized()) then
+     !   call shr_wtracers_finalize(rc)
+     !end if
+  end subroutine tearDown
+
+  ! ------------------------------------------------------------------------
+  ! Tests of shr_wtracers_check_tracer_ratios
+  ! ------------------------------------------------------------------------
+
+   @Test
+   subroutine test_shr_wiso_liq_vap_equil_frac_factor(this)
+      ! Test that the liquid/vapor equilibrium fractionation factor
+      ! function produces correct values.
+
+      use shr_wiso_mod, only: wiso_alpl
+
+      class(TestShrWiso), intent(inout) :: this
+
+      integer, parameter :: h2o_spec_idx = 1
+      real(r8)           :: h2o_liq_vap_frac
+
+      ! Calculate the fractionation factor for H216O (H2O):
+      h2o_liq_vap_frac = wiso_alpl(h2o_spec_idx, 273.15_r8)
+
+      ! Check that a bulk (H2O) water species always returns one:
+      @assertEqual(1._r8, h2o_liq_vap_frac)
+
+   end subroutine test_shr_wiso_liq_vap_equil_frac_factor
+
+end module test_shr_wiso

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -6,6 +6,11 @@ module test_shr_wiso
    use funit
    use shr_kind_mod, only: r8=>SHR_KIND_R8
 
+   ! shr_wtracers_mod variables needed for testing:
+   use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
+   use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
+   use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
+
    ! shr_wiso_mod routines being tested
    use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
    use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
@@ -20,6 +25,15 @@ module test_shr_wiso
       procedure :: tearDown
    end type TestShrWiso
 
+   ! parameters useful for testing
+   !integer,  parameter :: ntemps = 9
+
+   real(r8), parameter :: liq_temps(9) = [233._r8, 243._r8, 253._r8, 263._r8, &
+                                          273._r8, 283._r8, 293._r8, 303._r8, 313._r8]
+
+   real(r8), parameter :: ice_temps(8) = [203._r8, 213._r8, 223._r8, 233._r8, &
+                                          243._r8, 253._r8, 263._r8, 273._r8]
+
 contains
 
   subroutine setUp(this)
@@ -28,12 +42,6 @@ contains
 
   subroutine tearDown(this)
      class(TestShrWiso), intent(inout) :: this
-
-     !integer :: rc
-
-     !if (shr_wtracers_initialized()) then
-     !   call shr_wtracers_finalize(rc)
-     !end if
   end subroutine tearDown
 
   ! ------------------------------------------------------------------------
@@ -43,7 +51,7 @@ contains
    @Test
    subroutine test_shr_wiso_liq_vap_equil_frac_factor_h2o(this)
       ! Test that the liquid/vapor equilibrium fractionation factor
-      ! function produces correct values for H2O.
+      ! function produces the correct value for H2O.
 
       class(TestShrWiso), intent(inout) :: this
 
@@ -67,8 +75,6 @@ contains
       ! function raises an exception when given a bad isotope species
       ! index.
 
-      use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
-
       class(TestShrWiso), intent(inout) :: this
 
       integer, parameter :: bad_spec_idx = 78
@@ -82,6 +88,105 @@ contains
       @assertExceptionRaised("ABORTED: wiso_liq_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = 78")
 
    end subroutine test_shr_wiso_liq_vap_equil_frac_factor_bad_idx
+
+  !+++
+
+   @Test
+   subroutine test_shr_wiso_liq_vap_equil_frac_factor_h218o_properties(this)
+      ! Test that the reciprocal of the H218O liquid/vapor equilibrium fractionation
+      ! factor lies strictly between 0 and 1 for temperatures from 233 K to 313 K,
+      ! and that the reciprocal increases with increasing temperature.
+
+      class(TestShrWiso), intent(inout) :: this
+   
+      real(r8) :: vap_liq_frac_18O       ! Reciprocal of the H218O liquid/vapor equilibrium fractionation factor
+      real(r8) :: vap_liq_frac_18O_prev
+      integer  :: i
+
+      ! Calculate first function value, and check that it is greater than zero:
+      vap_liq_frac_18O_prev = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, liq_temps(1))
+
+      @assertTrue(vap_liq_frac_18O_prev > 0._r8)
+
+      ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/liquid)
+      ! values increase with increasing temperature:
+      do i = 2, size(liq_temps)
+         vap_liq_frac_18O = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, liq_temps(i))
+   
+         @assertTrue(vap_liq_frac_18O > vap_liq_frac_18O_prev)
+         vap_liq_frac_18O_prev = vap_liq_frac_18O
+      end do
+
+      ! Finally, check that the last value is less than one:
+      @assertTrue(vap_liq_frac_18O < 1._r8)
+
+   end subroutine test_shr_wiso_liq_vap_equil_frac_factor_h218o_properties
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_liq_vap_equil_frac_factor_h217o_properties(this)
+      ! Test that the reciprocal of the H217O liquid/vapor equilibrium fractionation
+      ! factor lies strictly between 0 and 1 for temperatures from 233 K to 313 K,
+      ! and that the reciprocal increases with increasing temperature.
+
+      class(TestShrWiso), intent(inout) :: this
+   
+      real(r8) :: vap_liq_frac_17O       ! Reciprocal of the H217O liquid/vapor equilibrium fractionation factor
+      real(r8) :: vap_liq_frac_17O_prev
+      integer  :: i
+
+      ! Calculate first function value, and check that it is greater than zero:
+      vap_liq_frac_17O_prev = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, liq_temps(1))
+
+      @assertTrue(vap_liq_frac_17O_prev > 0._r8)
+
+      ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/liquid)
+      ! values increase with increasing temperature:
+      do i = 2, size(liq_temps)
+         vap_liq_frac_17O = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, liq_temps(i))
+   
+         @assertTrue(vap_liq_frac_17O > vap_liq_frac_17O_prev)
+         vap_liq_frac_17O_prev = vap_liq_frac_17O
+      end do
+
+      ! Finally, check that the last value is less than one:
+      @assertTrue(vap_liq_frac_17O < 1._r8)
+
+   end subroutine test_shr_wiso_liq_vap_equil_frac_factor_h217o_properties
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_liq_vap_equil_frac_factor_hdo_properties(this)
+      ! Test that the reciprocal of the HDO liquid/vapor equilibrium fractionation
+      ! factor lies strictly between 0 and 1 for temperatures from 233 K to 313 K,
+      ! and that the reciprocal increases with increasing temperature.
+
+      class(TestShrWiso), intent(inout) :: this
+   
+      real(r8) :: vap_liq_frac_HDO       ! Reciprocal of the HDO liquid/vapor equilibrium fractionation factor
+      real(r8) :: vap_liq_frac_HDO_prev
+      integer  :: i
+
+      ! Calculate first function value, and check that it is greater than zero:
+      vap_liq_frac_HDO_prev = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, liq_temps(1))
+
+      @assertTrue(vap_liq_frac_HDO_prev > 0._r8)
+
+      ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/liquid)
+      ! values increase with increasing temperature:
+      do i = 2, size(liq_temps)
+         vap_liq_frac_HDO = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, liq_temps(i))
+   
+         @assertTrue(vap_liq_frac_HDO > vap_liq_frac_HDO_prev)
+         vap_liq_frac_HDO_prev = vap_liq_frac_HDO
+      end do
+
+      ! Finally, check that the last value is less than one:
+      @assertTrue(vap_liq_frac_HDO < 1._r8)
+
+   end subroutine test_shr_wiso_liq_vap_equil_frac_factor_hdo_properties
 
   ! ------------------------------------------------------------------------
   ! Tests of wiso_ice_vap_equil_frac_factor function
@@ -127,5 +232,104 @@ contains
       @assertExceptionRaised("ABORTED: wiso_ice_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = 78")
 
    end subroutine test_shr_wiso_ice_vap_equil_frac_factor_bad_idx
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_ice_vap_equil_frac_factor_h218o_properties(this)
+      ! Test that the reciprocal of the H218O ice/vapor equilibrium fractionation
+      ! factor lies strictly between 0 and 1 for temperatures from 203 K to 273 K,
+      ! and that the reciprocal increases with increasing temperature.
+
+      class(TestShrWiso), intent(inout) :: this
+   
+      real(r8) :: vap_ice_frac_18O       ! Reciprocal of the H218O ice/vapor equilibrium fractionation factor
+      real(r8) :: vap_ice_frac_18O_prev
+      integer  :: i
+
+      ! Calculate first function value, and check that it is greater than zero:
+      vap_ice_frac_18O_prev = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, ice_temps(1))
+
+      @assertTrue(vap_ice_frac_18O_prev > 0._r8)
+
+      ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/ice)
+      ! values increase with increasing temperature:
+      do i = 2, size(ice_temps)
+         vap_ice_frac_18O = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, ice_temps(i))
+   
+         @assertTrue(vap_ice_frac_18O > vap_ice_frac_18O_prev)
+         vap_ice_frac_18O_prev = vap_ice_frac_18O
+      end do
+
+      ! Finally, check that the last value is less than one:
+      @assertTrue(vap_ice_frac_18O < 1._r8)
+
+   end subroutine test_shr_wiso_ice_vap_equil_frac_factor_h218o_properties
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_ice_vap_equil_frac_factor_h217o_properties(this)
+      ! Test that the reciprocal of the H217O ice/vapor equilibrium fractionation
+      ! factor lies strictly between 0 and 1 for temperatures from 203 K to 273 K,
+      ! and that the reciprocal increases with increasing temperature.
+
+      class(TestShrWiso), intent(inout) :: this
+   
+      real(r8) :: vap_ice_frac_17O       ! Reciprocal of the H217O ice/vapor equilibrium fractionation factor
+      real(r8) :: vap_ice_frac_17O_prev
+      integer  :: i
+
+      ! Calculate first function value, and check that it is greater than zero:
+      vap_ice_frac_17O_prev = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, ice_temps(1))
+
+      @assertTrue(vap_ice_frac_17O_prev > 0._r8)
+
+      ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/ice)
+      ! values increase with increasing temperature:
+      do i = 2, size(ice_temps)
+         vap_ice_frac_17O = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, ice_temps(i))
+   
+         @assertTrue(vap_ice_frac_17O > vap_ice_frac_17O_prev)
+         vap_ice_frac_17O_prev = vap_ice_frac_17O
+      end do
+
+      ! Finally, check that the last value is less than one:
+      @assertTrue(vap_ice_frac_17O < 1._r8)
+
+   end subroutine test_shr_wiso_ice_vap_equil_frac_factor_h217o_properties
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_ice_vap_equil_frac_factor_hdo_properties(this)
+      ! Test that the reciprocal of the HDO ice/vapor equilibrium fractionation
+      ! factor lies strictly between 0 and 1 for temperatures from 203 K to 273 K,
+      ! and that the reciprocal increases with increasing temperature.
+
+      class(TestShrWiso), intent(inout) :: this
+   
+      real(r8) :: vap_ice_frac_HDO       ! Reciprocal of the HDO ice/vapor equilibrium fractionation factor
+      real(r8) :: vap_ice_frac_HDO_prev
+      integer  :: i
+
+      ! Calculate first function value, and check that it is greater than zero:
+      vap_ice_frac_HDO_prev = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, ice_temps(1))
+
+      @assertTrue(vap_ice_frac_HDO_prev > 0._r8)
+
+      ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/ice)
+      ! values increase with increasing temperature:
+      do i = 2, size(ice_temps)
+         vap_ice_frac_HDO = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, ice_temps(i))
+   
+         @assertTrue(vap_ice_frac_HDO > vap_ice_frac_HDO_prev)
+         vap_ice_frac_HDO_prev = vap_ice_frac_HDO
+      end do
+
+      ! Finally, check that the last value is less than one:
+      @assertTrue(vap_ice_frac_HDO < 1._r8)
+
+   end subroutine test_shr_wiso_ice_vap_equil_frac_factor_hdo_properties
 
 end module test_shr_wiso

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -7,6 +7,7 @@ module test_shr_wiso
    use shr_kind_mod, only: r8=>SHR_KIND_R8
 
    ! shr_wtracers_mod variables needed for testing:
+   use shr_wtracers_mod, only: WATER_SPECIES_TYPE_BULK
    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H218O
    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_H217O
    use shr_wtracers_mod, only: WATER_SPECIES_TYPE_HDO
@@ -14,6 +15,12 @@ module test_shr_wiso
    ! shr_wiso_mod routines being tested
    use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
    use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
+   use shr_wiso_mod, only: wiso_get_diffusivity_ratio
+
+   ! shr_wiso_mod parameters being tested
+   use shr_wiso_mod, only: DIFF_RATIO_H218O
+   use shr_wiso_mod, only: DIFF_RATIO_H217O
+   use shr_wiso_mod, only: DIFF_RATIO_HDO
 
 
    implicit none
@@ -349,5 +356,42 @@ contains
       @assertTrue(vap_ice_frac_HDO < 1._r8)
 
    end subroutine test_shr_wiso_ice_vap_equil_frac_factor_hdo_properties
+
+  ! ------------------------------------------------------------------------
+  ! Tests of wiso_get_diffusivity_ratio function
+  ! ------------------------------------------------------------------------
+
+   @Test
+   subroutine test_shr_wiso_get_diffusivity_ratio_values(this)
+      ! Test that the diffusivity ratio function returns the correct
+      ! value for all water species.
+
+      class(TestShrWiso), intent(inout) :: this
+
+      @assertEqual(1._r8,            wiso_get_diffusivity_ratio(WATER_SPECIES_TYPE_BULK))
+      @assertEqual(DIFF_RATIO_H218O, wiso_get_diffusivity_ratio(WATER_SPECIES_TYPE_H218O))
+      @assertEqual(DIFF_RATIO_H217O, wiso_get_diffusivity_ratio(WATER_SPECIES_TYPE_H217O))
+      @assertEqual(DIFF_RATIO_HDO,   wiso_get_diffusivity_ratio(WATER_SPECIES_TYPE_HDO))
+
+   end subroutine test_shr_wiso_get_diffusivity_ratio_values
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_get_diffusivity_ratio_bad_idx(this)
+      ! Test that the diffusivity ratio function raises an exception
+      ! when given a bad isotope species index.
+
+      class(TestShrWiso), intent(inout) :: this
+
+      integer, parameter :: bad_spec_idx = 78
+
+      real(r8) :: diff_ratio
+
+      diff_ratio = wiso_get_diffusivity_ratio(bad_spec_idx)
+
+      @assertExceptionRaised("ABORTED: wiso_get_diffusivity_ratio: ERROR: bad isotope species index; bad index = 78")
+
+   end subroutine test_shr_wiso_get_diffusivity_ratio_bad_idx
 
 end module test_shr_wiso

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -2,9 +2,14 @@ module test_shr_wiso
 
    ! Tests of shr_wiso_mod
 
+   ! modules and kinds needed for testing infrastructure
    use funit
-   use shr_wiso_mod
    use shr_kind_mod, only: r8=>SHR_KIND_R8
+
+   ! shr_wiso_mod routines being tested
+   use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
+   use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
+
 
    implicit none
 
@@ -39,8 +44,6 @@ contains
    subroutine test_shr_wiso_liq_vap_equil_frac_factor_h2o(this)
       ! Test that the liquid/vapor equilibrium fractionation factor
       ! function produces correct values for H2O.
-
-      use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
 
       class(TestShrWiso), intent(inout) :: this
 
@@ -89,8 +92,6 @@ contains
       ! Test that the ice/vapor equilibrium fractionation factor
       ! function produces correct values for H2O.
 
-      use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
-
       class(TestShrWiso), intent(inout) :: this
 
       integer, parameter :: h2o_spec_idx = 0
@@ -112,8 +113,6 @@ contains
       ! Test that the ice/vapor equilibrium fractionation factor
       ! function raises an exception when given a bad isotope species
       ! index.
-
-      use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
 
       class(TestShrWiso), intent(inout) :: this
 

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -16,6 +16,7 @@ module test_shr_wiso
    use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
    use shr_wiso_mod, only: wiso_ice_vap_equil_frac_factor
    use shr_wiso_mod, only: wiso_get_diffusivity_ratio
+   use shr_wiso_mod, only: icam_atm_ocn_kinetic_frac_factor
 
    ! shr_wiso_mod parameters being tested
    use shr_wiso_mod, only: DIFF_RATIO_H218O
@@ -393,5 +394,197 @@ contains
       @assertExceptionRaised("ABORTED: wiso_get_diffusivity_ratio: ERROR: bad isotope species index; bad index = 78")
 
    end subroutine test_shr_wiso_get_diffusivity_ratio_bad_idx
+
+  ! ------------------------------------------------------------------------
+  ! Tests of icam_atm_ocn_kinetic_frac_factor function
+  ! ------------------------------------------------------------------------
+
+   @Test
+   subroutine test_shr_wiso_atm_ocn_kinetic_frac_diff_ratio(this)
+      ! Test that the kinetic fractionation factor increases as the isotopic
+      ! diffusion ratio increases.
+      !
+      ! In general the kinetic fractionation factor should be smallest (i.e.
+      ! produce the greatest vapor ratio difference) for H218O,
+      ! because it is the most massive.
+      !
+      ! HDO should also be smaller (or have a larger vapor ratio difference)
+      ! relative to H217O, but in this case it is not strictly the mass
+      ! difference that is the culprit, but instead other molecular properties
+      ! (e.g. a loss of symmetry in HDO).
+
+      class(TestShrWiso), intent(inout) :: this
+
+      ! Fixed inputs (rough regime):
+      real(r8), parameter :: rbot  = 1.2_r8     ! density of lowest layer [kg m-3]
+      real(r8), parameter :: zbot  = 30._r8     ! height of lowest atmospheric layer [m]
+      real(r8), parameter :: zoq   = 1.e-3_r8   ! surface roughness length for water [m]
+      real(r8), parameter :: ustar = 0.5_r8     ! friction velocity [m s-1]
+
+      real(r8) :: alpkn_18O   ! kinetic fractionation factor for H218O
+      real(r8) :: alpkn_17O   ! kinetic fractionation factor for H217O
+      real(r8) :: alpkn_HDO   ! kinetic fractionation factor for HDO
+
+      ! Calculate the kinetic fractionation factor for each isotopic species:
+      alpkn_18O = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustar, DIFF_RATIO_H218O)
+      alpkn_HDO = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustar, DIFF_RATIO_HDO)
+      alpkn_17O = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustar, DIFF_RATIO_H217O)
+
+      ! Heavy isotopologues generally never diffuse faster than
+      ! lighter isotopologues, so ensure values are always less than one:
+      @assertTrue(alpkn_18O < 1._r8)
+      @assertTrue(alpkn_HDO < 1._r8)
+      @assertTrue(alpkn_17O < 1._r8)
+
+      ! There is likely a theoretical lower limit greater than zero
+      ! but for these tests just set a number that is very unlikely
+      ! to be seen in the Earth System, at least for atmosphere/ocean
+      ! fluxes:
+      @assertTrue(alpkn_18O > 0.7_r8)
+      @assertTrue(alpkn_HDO > 0.7_r8)
+      @assertTrue(alpkn_17O > 0.7_r8)
+
+      ! The factor should increase as the diffusion ratio increases:
+      @assertTrue(alpkn_18O < alpkn_HDO)
+      @assertTrue(alpkn_HDO < alpkn_17O)
+
+   end subroutine test_shr_wiso_atm_ocn_kinetic_frac_diff_ratio
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_atm_ocn_kinetic_frac_ustar_rough(this)
+      ! Test that, in the rough regime, the kinetic fractionation factor
+      ! decreases (i.e. the vapor ratio difference increases) as the
+      ! friction velocity increases, with all other inputs held fixed.
+
+      class(TestShrWiso), intent(inout) :: this
+
+      ! Fixed inputs (rough regime):
+      real(r8), parameter :: rbot = 1.2_r8      ! density of lowest layer [kg m-3]
+      real(r8), parameter :: zbot = 30._r8      ! height of lowest atmospheric layer [m]
+      real(r8), parameter :: zoq  = 1.e-3_r8    ! surface roughness length for water [m]
+
+      ! Monotonically increasing friction velocities [m s-1]:
+      real(r8), parameter :: ustars(5) = [0.1_r8, 0.2_r8, 0.4_r8, 0.8_r8, 1.0_r8]
+
+      real(r8) :: alpkn        ! kinetic fractionation factor
+      real(r8) :: alpkn_prev
+      integer  :: i
+
+      ! Calculate the first kinetic fractionation factor value (using H218O):
+      alpkn_prev = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustars(1), DIFF_RATIO_H218O)
+
+      ! check that it is less than the physically-allowed upper limit:
+      @assertTrue(alpkn_prev < 1._r8)
+
+      ! Loop over the remaining friction velocities, checking that the factor
+      ! decreases as ustar increases:
+      do i = 2, size(ustars)
+         alpkn = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustars(i), DIFF_RATIO_H218O)
+
+         @assertTrue(alpkn < alpkn_prev)
+         alpkn_prev = alpkn
+      end do
+
+      ! Check that the final value is still greater than the expected lower limit:
+      @assertTrue(alpkn_prev > 0.7_r8)
+
+   end subroutine test_shr_wiso_atm_ocn_kinetic_frac_ustar_rough
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_atm_ocn_kinetic_frac_zoq_rough(this)
+      ! Test that, in the rough regime, the kinetic fractionation factor
+      ! decreases (i.e. the vapor ratio difference increases) as the
+      ! surface roughness length (zoq) increases, with all other
+      ! inputs held fixed.
+
+      class(TestShrWiso), intent(inout) :: this
+
+      ! Fixed inputs (rough regime):
+      real(r8), parameter :: rbot  = 1.2_r8     ! density of lowest layer [kg m-3]
+      real(r8), parameter :: zbot  = 30._r8     ! height of lowest atmospheric layer [m]
+      real(r8), parameter :: ustar = 0.5_r8     ! friction velocity [m s-1]
+
+      ! Monotonically increasing surface roughness lengths [m]:
+      real(r8), parameter :: zoqs(5) = [5.e-4_r8, 1.e-3_r8, 2.e-3_r8, 4.e-3_r8, 8.e-3_r8]
+
+      real(r8) :: alpkn        ! kinetic fractionation factor
+      real(r8) :: alpkn_prev
+      integer  :: i
+
+      ! Calculate the first kinetic fractionation factor value (using H218O):
+      alpkn_prev = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoqs(1), ustar, DIFF_RATIO_H218O)
+
+      ! check that it is less than the physically-allowed upper limit:
+      @assertTrue(alpkn_prev < 1._r8)
+
+      ! Loop over the remaining roughness lengths, checking that the factor
+      ! decreases as zoq increases:
+      do i = 2, size(zoqs)
+         alpkn = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoqs(i), ustar, DIFF_RATIO_H218O)
+
+         @assertTrue(alpkn < alpkn_prev)
+         alpkn_prev = alpkn
+      end do
+
+      ! Check that the final value is still greater than the expected lower limit:
+      @assertTrue(alpkn_prev > 0.7_r8)
+
+   end subroutine test_shr_wiso_atm_ocn_kinetic_frac_zoq_rough
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_atm_ocn_kinetic_frac_ustar_smooth(this)
+      ! Test that, in the smooth regime, the kinetic fractionation factor
+      ! increases (i.e. the vapor ratio difference decreases )as the friction
+      ! velocity (ustar) increases, with all other inputs held fixed.
+      !
+      ! Note that this is the opposite of the behavior in the rough regime,
+      ! as the fluid should theoretically still be laminar, and thus
+      ! an increase in wind speed results in an increase in parcel deformation
+      ! and thus more efficient molecular diffusion.  At least this is my
+      ! working hypothesis. -JN.
+      !
+      ! A small roughness length is used here so that the surface Reynolds
+      ! number stays below the critical value (i.e. the smooth regime) for all
+      ! of the friction velocities tested below.
+
+      class(TestShrWiso), intent(inout) :: this
+
+      ! Fixed inputs (smooth regime):
+      real(r8), parameter :: rbot = 1.2_r8      ! density of lowest layer [kg m-3]
+      real(r8), parameter :: zbot = 30._r8      ! height of lowest atmospheric layer [m]
+      real(r8), parameter :: zoq  = 1.e-4_r8    ! surface roughness length for water [m]
+
+      ! Monotonically increasing friction velocities [m s-1]:
+      real(r8), parameter :: ustars(5) = [0.02_r8, 0.04_r8, 0.06_r8, 0.08_r8, 0.1_r8]
+
+      real(r8) :: alpkn        ! kinetic fractionation factor
+      real(r8) :: alpkn_prev
+      integer  :: i
+
+      ! Calculate the first kinetic fractionation factor value (using H218O):
+      alpkn_prev = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustars(1), DIFF_RATIO_H218O)
+
+      ! Check that it is greater than the expected lower limit:
+      @assertTrue(alpkn_prev > 0.7_r8)
+
+      ! Loop over the remaining friction velocities,
+      ! checking that the factor increases as ustar increases:
+      do i = 2, size(ustars)
+         alpkn = icam_atm_ocn_kinetic_frac_factor(rbot, zbot, zoq, ustars(i), DIFF_RATIO_H218O)
+
+         @assertTrue(alpkn > alpkn_prev)
+         alpkn_prev = alpkn
+      end do
+
+      ! check that the final value is less than the physically-allowed upper limit:
+      @assertTrue(alpkn_prev < 1._r8)
+
+   end subroutine test_shr_wiso_atm_ocn_kinetic_frac_ustar_smooth
 
 end module test_shr_wiso

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -34,7 +34,6 @@ module test_shr_wiso
    end type TestShrWiso
 
    ! parameters useful for testing
-   !integer,  parameter :: ntemps = 9
 
    real(r8), parameter :: liq_temps(9) = [233._r8, 243._r8, 253._r8, 263._r8, &
                                           273._r8, 283._r8, 293._r8, 303._r8, 313._r8]

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -94,25 +94,28 @@ contains
    @Test
    subroutine test_shr_wiso_liq_vap_equil_frac_factor_h218o_properties(this)
       ! Test that the reciprocal of the H218O liquid/vapor equilibrium fractionation
-      ! factor lies strictly between 0 and 1 for temperatures from 233 K to 313 K,
+      ! factor lies strictly between 0.7 and 1 for temperatures from 233 K to 313 K,
       ! and that the reciprocal increases with increasing temperature.
+      !
+      ! Note that technically 0.7 is physically possible, just significantly outside the temperature
+      ! range seen in the Earth System.
 
       class(TestShrWiso), intent(inout) :: this
-   
+
       real(r8) :: vap_liq_frac_18O       ! Reciprocal of the H218O liquid/vapor equilibrium fractionation factor
       real(r8) :: vap_liq_frac_18O_prev
       integer  :: i
 
-      ! Calculate first function value, and check that it is greater than zero:
+      ! Calculate first function value, and check that it is greater than 0.7:
       vap_liq_frac_18O_prev = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, liq_temps(1))
 
-      @assertTrue(vap_liq_frac_18O_prev > 0._r8)
+      @assertTrue(vap_liq_frac_18O_prev > 0.7_r8)
 
       ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/liquid)
       ! values increase with increasing temperature:
       do i = 2, size(liq_temps)
          vap_liq_frac_18O = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, liq_temps(i))
-   
+
          @assertTrue(vap_liq_frac_18O > vap_liq_frac_18O_prev)
          vap_liq_frac_18O_prev = vap_liq_frac_18O
       end do
@@ -127,25 +130,28 @@ contains
    @Test
    subroutine test_shr_wiso_liq_vap_equil_frac_factor_h217o_properties(this)
       ! Test that the reciprocal of the H217O liquid/vapor equilibrium fractionation
-      ! factor lies strictly between 0 and 1 for temperatures from 233 K to 313 K,
+      ! factor lies strictly between 0.7 and 1 for temperatures from 233 K to 313 K,
       ! and that the reciprocal increases with increasing temperature.
+      !
+      ! Note that technically 0.7 is physically possible, just significantly outside
+      ! the temperature range seen in the Earth System.
 
       class(TestShrWiso), intent(inout) :: this
-   
+
       real(r8) :: vap_liq_frac_17O       ! Reciprocal of the H217O liquid/vapor equilibrium fractionation factor
       real(r8) :: vap_liq_frac_17O_prev
       integer  :: i
 
-      ! Calculate first function value, and check that it is greater than zero:
+      ! Calculate first function value, and check that it is greater than 0.7:
       vap_liq_frac_17O_prev = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, liq_temps(1))
 
-      @assertTrue(vap_liq_frac_17O_prev > 0._r8)
+      @assertTrue(vap_liq_frac_17O_prev > 0.7_r8)
 
       ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/liquid)
       ! values increase with increasing temperature:
       do i = 2, size(liq_temps)
          vap_liq_frac_17O = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, liq_temps(i))
-   
+
          @assertTrue(vap_liq_frac_17O > vap_liq_frac_17O_prev)
          vap_liq_frac_17O_prev = vap_liq_frac_17O
       end do
@@ -160,25 +166,28 @@ contains
    @Test
    subroutine test_shr_wiso_liq_vap_equil_frac_factor_hdo_properties(this)
       ! Test that the reciprocal of the HDO liquid/vapor equilibrium fractionation
-      ! factor lies strictly between 0 and 1 for temperatures from 233 K to 313 K,
+      ! factor lies strictly between 0.7 and 1 for temperatures from 233 K to 313 K,
       ! and that the reciprocal increases with increasing temperature.
+      !
+      ! Note that technically 0.7 is physically possible, just significantly outside
+      ! the temperature range seen in the Earth System.
 
       class(TestShrWiso), intent(inout) :: this
-   
+
       real(r8) :: vap_liq_frac_HDO       ! Reciprocal of the HDO liquid/vapor equilibrium fractionation factor
       real(r8) :: vap_liq_frac_HDO_prev
       integer  :: i
 
-      ! Calculate first function value, and check that it is greater than zero:
+      ! Calculate first function value, and check that it is greater than 0.7:
       vap_liq_frac_HDO_prev = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, liq_temps(1))
 
-      @assertTrue(vap_liq_frac_HDO_prev > 0._r8)
+      @assertTrue(vap_liq_frac_HDO_prev > 0.7_r8)
 
       ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/liquid)
       ! values increase with increasing temperature:
       do i = 2, size(liq_temps)
          vap_liq_frac_HDO = 1._r8 / wiso_liq_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, liq_temps(i))
-   
+
          @assertTrue(vap_liq_frac_HDO > vap_liq_frac_HDO_prev)
          vap_liq_frac_HDO_prev = vap_liq_frac_HDO
       end do
@@ -238,25 +247,28 @@ contains
    @Test
    subroutine test_shr_wiso_ice_vap_equil_frac_factor_h218o_properties(this)
       ! Test that the reciprocal of the H218O ice/vapor equilibrium fractionation
-      ! factor lies strictly between 0 and 1 for temperatures from 203 K to 273 K,
+      ! factor lies strictly between 0.7 and 1 for temperatures from 203 K to 273 K,
       ! and that the reciprocal increases with increasing temperature.
+      !
+      ! Note that technically 0.7 is physically possible, just significantly outside
+      ! the temperature range seen in the Earth System.
 
       class(TestShrWiso), intent(inout) :: this
-   
+
       real(r8) :: vap_ice_frac_18O       ! Reciprocal of the H218O ice/vapor equilibrium fractionation factor
       real(r8) :: vap_ice_frac_18O_prev
       integer  :: i
 
-      ! Calculate first function value, and check that it is greater than zero:
+      ! Calculate first function value, and check that it is greater than 0.7:
       vap_ice_frac_18O_prev = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, ice_temps(1))
 
-      @assertTrue(vap_ice_frac_18O_prev > 0._r8)
+      @assertTrue(vap_ice_frac_18O_prev > 0.7_r8)
 
       ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/ice)
       ! values increase with increasing temperature:
       do i = 2, size(ice_temps)
          vap_ice_frac_18O = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H218O, ice_temps(i))
-   
+
          @assertTrue(vap_ice_frac_18O > vap_ice_frac_18O_prev)
          vap_ice_frac_18O_prev = vap_ice_frac_18O
       end do
@@ -271,25 +283,28 @@ contains
    @Test
    subroutine test_shr_wiso_ice_vap_equil_frac_factor_h217o_properties(this)
       ! Test that the reciprocal of the H217O ice/vapor equilibrium fractionation
-      ! factor lies strictly between 0 and 1 for temperatures from 203 K to 273 K,
+      ! factor lies strictly between 0.7 and 1 for temperatures from 203 K to 273 K,
       ! and that the reciprocal increases with increasing temperature.
+      !
+      ! Note that technically 0.7 is physically possible, just significantly outside
+      ! the temperature range seen in the Earth System.
 
       class(TestShrWiso), intent(inout) :: this
-   
+
       real(r8) :: vap_ice_frac_17O       ! Reciprocal of the H217O ice/vapor equilibrium fractionation factor
       real(r8) :: vap_ice_frac_17O_prev
       integer  :: i
 
-      ! Calculate first function value, and check that it is greater than zero:
+      ! Calculate first function value, and check that it is greater than 0.7:
       vap_ice_frac_17O_prev = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, ice_temps(1))
 
-      @assertTrue(vap_ice_frac_17O_prev > 0._r8)
+      @assertTrue(vap_ice_frac_17O_prev > 0.7_r8)
 
       ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/ice)
       ! values increase with increasing temperature:
       do i = 2, size(ice_temps)
          vap_ice_frac_17O = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_H217O, ice_temps(i))
-   
+
          @assertTrue(vap_ice_frac_17O > vap_ice_frac_17O_prev)
          vap_ice_frac_17O_prev = vap_ice_frac_17O
       end do
@@ -304,25 +319,28 @@ contains
    @Test
    subroutine test_shr_wiso_ice_vap_equil_frac_factor_hdo_properties(this)
       ! Test that the reciprocal of the HDO ice/vapor equilibrium fractionation
-      ! factor lies strictly between 0 and 1 for temperatures from 203 K to 273 K,
+      ! factor lies strictly between 0.7 and 1 for temperatures from 203 K to 273 K,
       ! and that the reciprocal increases with increasing temperature.
+      !
+      ! Note that technically 0.7 is physically possible, just significantly outside
+      ! the temperature range seen in the Earth System.
 
       class(TestShrWiso), intent(inout) :: this
-   
+
       real(r8) :: vap_ice_frac_HDO       ! Reciprocal of the HDO ice/vapor equilibrium fractionation factor
       real(r8) :: vap_ice_frac_HDO_prev
       integer  :: i
 
-      ! Calculate first function value, and check that it is greater than zero:
+      ! Calculate first function value, and check that it is greater than 0.7:
       vap_ice_frac_HDO_prev = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, ice_temps(1))
 
-      @assertTrue(vap_ice_frac_HDO_prev > 0._r8)
+      @assertTrue(vap_ice_frac_HDO_prev > 0.7_r8)
 
       ! Now loop over the rest of the temperatures, checking that the reciprocal (vapor/ice)
       ! values increase with increasing temperature:
       do i = 2, size(ice_temps)
          vap_ice_frac_HDO = 1._r8 / wiso_ice_vap_equil_frac_factor(WATER_SPECIES_TYPE_HDO, ice_temps(i))
-   
+
          @assertTrue(vap_ice_frac_HDO > vap_ice_frac_HDO_prev)
          vap_ice_frac_HDO_prev = vap_ice_frac_HDO
       end do

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -32,27 +32,52 @@ contains
   end subroutine tearDown
 
   ! ------------------------------------------------------------------------
-  ! Tests of shr_wtracers_check_tracer_ratios
+  ! Tests of wiso_liq_vap_equil_frac_factor function
   ! ------------------------------------------------------------------------
 
    @Test
-   subroutine test_shr_wiso_liq_vap_equil_frac_factor(this)
+   subroutine test_shr_wiso_liq_vap_equil_frac_factor_h2o(this)
       ! Test that the liquid/vapor equilibrium fractionation factor
-      ! function produces correct values.
+      ! function produces correct values for H2O.
 
-      use shr_wiso_mod, only: wiso_alpl
+      use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
 
       class(TestShrWiso), intent(inout) :: this
 
       integer, parameter :: h2o_spec_idx = 1
+
       real(r8)           :: h2o_liq_vap_frac
 
       ! Calculate the fractionation factor for H216O (H2O):
-      h2o_liq_vap_frac = wiso_alpl(h2o_spec_idx, 273.15_r8)
+      h2o_liq_vap_frac = wiso_liq_vap_equil_frac_factor(h2o_spec_idx, 273.15_r8)
 
       ! Check that a bulk (H2O) water species always returns one:
       @assertEqual(1._r8, h2o_liq_vap_frac)
 
-   end subroutine test_shr_wiso_liq_vap_equil_frac_factor
+   end subroutine test_shr_wiso_liq_vap_equil_frac_factor_h2o
+
+   !+++
+
+   @Test
+   subroutine test_shr_wiso_liq_vap_equil_frac_factor_bad_idx(this)
+      ! Test that the liquid/vapor equilibrium fractionation factor
+      ! function returns an unphysical value when given a bad isotope
+      ! index.
+
+      use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
+
+      class(TestShrWiso), intent(inout) :: this
+
+      integer, parameter :: bad_spec_idx = 78
+
+      real(r8)           :: bad_idx_frac
+
+      ! Try using a bad isotope index:
+      bad_idx_frac = wiso_liq_vap_equil_frac_factor(bad_spec_idx, 273.15_r8)
+
+      ! Check that the fractionation factor is negative huge:
+      @assertEqual(-huge(1._r8), bad_idx_frac)
+
+   end subroutine test_shr_wiso_liq_vap_equil_frac_factor_bad_idx
 
 end module test_shr_wiso

--- a/test/unit/shr_wiso_test/test_shr_wiso.pf
+++ b/test/unit/shr_wiso_test/test_shr_wiso.pf
@@ -61,7 +61,7 @@ contains
    @Test
    subroutine test_shr_wiso_liq_vap_equil_frac_factor_bad_idx(this)
       ! Test that the liquid/vapor equilibrium fractionation factor
-      ! function returns an unphysical value when given a bad isotope
+      ! function raises an exception when given a bad isotope species
       ! index.
 
       use shr_wiso_mod, only: wiso_liq_vap_equil_frac_factor
@@ -76,7 +76,10 @@ contains
       bad_idx_frac = wiso_liq_vap_equil_frac_factor(bad_spec_idx, 273.15_r8)
 
       ! Check that the fractionation factor is negative huge:
-      @assertEqual(-huge(1._r8), bad_idx_frac)
+      !@assertEqual(-huge(1._r8), bad_idx_frac)
+
+      ! Check that an exception was raised:
+      @assertExceptionRaised("ABORTED: wiso_liq_vap_equil_frac_factor: ERROR: bad isotope species index; bad index = 78")
 
    end subroutine test_shr_wiso_liq_vap_equil_frac_factor_bad_idx
 


### PR DESCRIPTION
This PR adds a new module (`shr_wiso_mod.F90`) that contains functions potentially useable across all CESM components for the calculation of fractionation factors for H218O, H217O, and HDO.  Note that additional calculations will likely be added here in the future, but this represents the bare minimum that I know will be needed by multiple components.

Along with the functions themselves, several pFUnit tests were added to make sure that the functions are working as expected.  The tests were written by Claude Opus under my guidance.